### PR TITLE
Add tmux namespace inheritance and compatibility helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The controller orchestrates workers through shell scripts that manage tmux sessi
 
 When `launch-worker.sh` runs inside tmux, it namespaces worker session names with the current session by default (for example, `fresh-worker-1`). This keeps worker sessions grouped with the coordinator context. Set `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_MODE=off` to disable, `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE` to override the namespace root, and `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_DELIM` to change the separator. To launch workers via a different command (for example a wrapper), set `CLAUDE_SESSION_DRIVER_LAUNCH_CMD`.
 
+`launch-worker.sh` returns both the requested tmux name and resolved `tmux_name`; use the resolved `tmux_name` for follow-up commands. `send-prompt.sh` also accepts an optional `session_id` argument for deterministic targeting when requested names collide across namespaces.
+
 ## Installation
 
 ```bash
@@ -38,7 +40,7 @@ Install the plugin and ask Claude to manage a project. The `driving-claude-code-
 |--------|---------|
 | `launch-worker.sh` | Start a worker session in tmux |
 | `converse.sh` | Send a prompt, wait, return the response |
-| `send-prompt.sh` | Send a prompt without waiting |
+| `send-prompt.sh` | Send a prompt without waiting (`<tmux-name> <prompt> [session-id]`) |
 | `wait-for-event.sh` | Block until a lifecycle event appears |
 | `read-events.sh` | Read and filter the event stream |
 | `read-turn.sh` | Format the last turn as markdown |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Each worker session loads hooks that write lifecycle events to a JSONL file: ses
 
 The controller orchestrates workers through shell scripts that manage tmux sessions, poll events, read conversation logs, and clean up.
 
-When `launch-worker.sh` runs inside tmux, it namespaces worker session names with the current session by default (for example, `fresh-worker-1`). This keeps worker sessions grouped with the coordinator context. Set `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_MODE=off` to disable, `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE` to override the namespace root, and `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_DELIM` to change the separator. To launch workers via a different command (for example a wrapper), set `CLAUDE_SESSION_DRIVER_LAUNCH_CMD`.
+When `launch-worker.sh` runs inside tmux, it namespaces worker session names with the current session by default (for example, `fresh-worker-1`). This keeps worker sessions grouped with the coordinator context. Set `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_MODE=off` to disable, `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE` to override the namespace root, and `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_DELIM` to change the separator. Outside tmux, single-session namespace inference is disabled by default; enable it explicitly with `CLAUDE_SESSION_DRIVER_INFER_NAMESPACE=true` if you want that behavior. To launch workers via a different command, set `CLAUDE_SESSION_DRIVER_LAUNCH_CMD` to an executable name or path.
 
 Set `CLAUDE_SESSION_DRIVER_TMUX_SCOPE=window` to launch workers as windows in the parent tmux session (window-level orchestration). The default scope is `session`.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Each worker session loads hooks that write lifecycle events to a JSONL file: ses
 
 The controller orchestrates workers through shell scripts that manage tmux sessions, poll events, read conversation logs, and clean up.
 
+When `launch-worker.sh` runs inside tmux, it namespaces worker session names with the current session by default (for example, `fresh-worker-1`). This keeps worker sessions grouped with the coordinator context. Set `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_MODE=off` to disable, `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE` to override the namespace root, and `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_DELIM` to change the separator. To launch workers via a different command (for example a wrapper), set `CLAUDE_SESSION_DRIVER_LAUNCH_CMD`.
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ The controller orchestrates workers through shell scripts that manage tmux sessi
 
 When `launch-worker.sh` runs inside tmux, it namespaces worker session names with the current session by default (for example, `fresh-worker-1`). This keeps worker sessions grouped with the coordinator context. Set `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_MODE=off` to disable, `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE` to override the namespace root, and `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_DELIM` to change the separator. To launch workers via a different command (for example a wrapper), set `CLAUDE_SESSION_DRIVER_LAUNCH_CMD`.
 
-`launch-worker.sh` returns both the requested tmux name and resolved `tmux_name`; use the resolved `tmux_name` for follow-up commands. `send-prompt.sh` also accepts an optional `session_id` argument for deterministic targeting when requested names collide across namespaces.
+Set `CLAUDE_SESSION_DRIVER_TMUX_SCOPE=window` to launch workers as windows in the parent tmux session (window-level orchestration). The default scope is `session`.
+
+`launch-worker.sh` returns both the requested tmux name and resolved `tmux_name` (plus `tmux_scope`); use the resolved `tmux_name` for follow-up commands. `send-prompt.sh` also accepts an optional `session_id` argument for deterministic targeting when requested names collide across namespaces.
 
 ## Installation
 
@@ -38,7 +40,7 @@ Install the plugin and ask Claude to manage a project. The `driving-claude-code-
 
 | Script | Purpose |
 |--------|---------|
-| `launch-worker.sh` | Start a worker session in tmux |
+| `launch-worker.sh` | Start a worker in tmux (session or window scope) |
 | `converse.sh` | Send a prompt, wait, return the response |
 | `send-prompt.sh` | Send a prompt without waiting (`<tmux-name> <prompt> [session-id]`) |
 | `wait-for-event.sh` | Block until a lifecycle event appears |

--- a/scripts/converse.sh
+++ b/scripts/converse.sh
@@ -61,7 +61,7 @@ if [ -f "$EVENT_FILE" ]; then
 fi
 
 # Send the prompt
-bash "$SCRIPT_DIR/send-prompt.sh" "$TMUX_NAME" "$PROMPT_TEXT"
+bash "$SCRIPT_DIR/send-prompt.sh" "$TMUX_NAME" "$PROMPT_TEXT" "$SESSION_ID"
 
 # Wait for the worker to finish
 if ! bash "$SCRIPT_DIR/wait-for-event.sh" "$SESSION_ID" stop "$TIMEOUT" --after-line "$AFTER_LINE" > /dev/null; then

--- a/scripts/launch-worker.sh
+++ b/scripts/launch-worker.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 #
 # Usage: launch-worker.sh <tmux-name> <working-dir> [extra claude args...]
 
-TMUX_NAME="${1:?Usage: launch-worker.sh <tmux-name> <working-dir> [extra claude args...]}"
+REQUESTED_TMUX_NAME="${1:?Usage: launch-worker.sh <tmux-name> <working-dir> [extra claude args...]}"
 WORKING_DIR="${2:?Usage: launch-worker.sh <tmux-name> <working-dir> [extra claude args...]}"
 shift 2
 EXTRA_ARGS=("$@")
@@ -14,6 +14,38 @@ EXTRA_ARGS=("$@")
 # Resolve plugin directory (parent of scripts/)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLAUDE_LAUNCH_CMD="${CLAUDE_SESSION_DRIVER_LAUNCH_CMD:-claude}"
+
+# Resolve worker tmux name. By default, inherit the parent tmux session name as
+# a namespace prefix so workers are grouped with the coordinator's session.
+NAMESPACE_MODE="${CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_MODE:-inherit}"
+NAMESPACE_DELIM="${CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_DELIM:--}"
+TMUX_NAMESPACE="${CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE:-}"
+
+case "$NAMESPACE_MODE" in
+  inherit|off)
+    ;;
+  *)
+    echo "Error: invalid CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_MODE '$NAMESPACE_MODE' (use inherit|off)" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "$TMUX_NAMESPACE" ] && [ "$NAMESPACE_MODE" = "inherit" ] && [ -n "${TMUX:-}" ]; then
+  TMUX_NAMESPACE="$(tmux display-message -p '#S' 2>/dev/null || true)"
+fi
+
+TMUX_NAME="$REQUESTED_TMUX_NAME"
+if [ "$NAMESPACE_MODE" = "inherit" ] && [ -n "$TMUX_NAMESPACE" ]; then
+  case "$REQUESTED_TMUX_NAME" in
+    "$TMUX_NAMESPACE"|"$TMUX_NAMESPACE${NAMESPACE_DELIM}"*)
+      TMUX_NAME="$REQUESTED_TMUX_NAME"
+      ;;
+    *)
+      TMUX_NAME="${TMUX_NAMESPACE}${NAMESPACE_DELIM}${REQUESTED_TMUX_NAME}"
+      ;;
+  esac
+fi
 
 # Resolve working directory to absolute physical path (resolves symlinks)
 WORKING_DIR="$(cd "$WORKING_DIR" && pwd -P)"
@@ -27,10 +59,19 @@ mkdir -p /tmp/claude-workers
 # Write metadata
 jq -n \
   --arg tmux_name "$TMUX_NAME" \
+  --arg requested_tmux_name "$REQUESTED_TMUX_NAME" \
+  --arg tmux_namespace "$TMUX_NAMESPACE" \
   --arg session_id "$SESSION_ID" \
   --arg cwd "$WORKING_DIR" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-  '{tmux_name: $tmux_name, session_id: $session_id, cwd: $cwd, started_at: $started_at}' \
+  '{
+    tmux_name: $tmux_name,
+    requested_tmux_name: $requested_tmux_name,
+    tmux_namespace: ($tmux_namespace | if . == "" then null else . end),
+    session_id: $session_id,
+    cwd: $cwd,
+    started_at: $started_at
+  }' \
   > "/tmp/claude-workers/${SESSION_ID}.meta"
 
 # Check for existing tmux session with this name
@@ -43,12 +84,17 @@ fi
 # Propagate approval timeout through tmux to the hook environment
 APPROVAL_TIMEOUT="${CLAUDE_SESSION_DRIVER_APPROVAL_TIMEOUT:-30}"
 
-# Launch claude in detached tmux session with permission bypass.
-# The PreToolUse hook provides controller-based gating, so the built-in
-# interactive permission dialog is redundant and would block the worker.
+# Launch worker in detached tmux via interactive zsh so aliases (e.g. `clauded`)
+# are available. Keep --dangerously-skip-permissions to avoid interactive stalls.
+LAUNCH_CMD="$CLAUDE_LAUNCH_CMD --session-id $(printf '%q' "$SESSION_ID") --plugin-dir $(printf '%q' "$PLUGIN_DIR") --dangerously-skip-permissions"
+for arg in "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"; do
+  LAUNCH_CMD+=" $(printf '%q' "$arg")"
+done
+
 tmux new-session -d -s "$TMUX_NAME" -c "$WORKING_DIR" \
   -e "CLAUDE_SESSION_DRIVER_APPROVAL_TIMEOUT=$APPROVAL_TIMEOUT" \
-  claude --session-id "$SESSION_ID" --plugin-dir "$PLUGIN_DIR" --dangerously-skip-permissions "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"
+  -e "CLAUDECODE=" \
+  zsh -lic "$LAUNCH_CMD"
 
 # Accept the workspace trust dialog (default selection is "Yes, I trust this folder")
 sleep 3
@@ -67,5 +113,6 @@ fi
 jq -n \
   --arg session_id "$SESSION_ID" \
   --arg tmux_name "$TMUX_NAME" \
+  --arg requested_tmux_name "$REQUESTED_TMUX_NAME" \
   --arg events_file "/tmp/claude-workers/${SESSION_ID}.events.jsonl" \
-  '{session_id: $session_id, tmux_name: $tmux_name, events_file: $events_file}'
+  '{session_id: $session_id, tmux_name: $tmux_name, requested_tmux_name: $requested_tmux_name, events_file: $events_file}'

--- a/scripts/launch-worker.sh
+++ b/scripts/launch-worker.sh
@@ -16,11 +16,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CLAUDE_LAUNCH_CMD="${CLAUDE_SESSION_DRIVER_LAUNCH_CMD:-claude}"
 
-# Resolve worker tmux name. By default, inherit the parent tmux session name as
-# a namespace prefix so workers are grouped with the coordinator's session.
+# Resolve worker tmux target. By default, workers are launched as tmux sessions.
+# Set CLAUDE_SESSION_DRIVER_TMUX_SCOPE=window to launch workers as windows
+# inside a parent tmux session.
 NAMESPACE_MODE="${CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_MODE:-inherit}"
 NAMESPACE_DELIM="${CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_DELIM:--}"
 TMUX_NAMESPACE="${CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE:-}"
+TMUX_SCOPE="${CLAUDE_SESSION_DRIVER_TMUX_SCOPE:-session}"
 
 case "$NAMESPACE_MODE" in
   inherit|off)
@@ -31,20 +33,63 @@ case "$NAMESPACE_MODE" in
     ;;
 esac
 
-if [ -z "$TMUX_NAMESPACE" ] && [ "$NAMESPACE_MODE" = "inherit" ] && [ -n "${TMUX:-}" ]; then
-  TMUX_NAMESPACE="$(tmux display-message -p '#S' 2>/dev/null || true)"
+case "$TMUX_SCOPE" in
+  session|window)
+    ;;
+  *)
+    echo "Error: invalid CLAUDE_SESSION_DRIVER_TMUX_SCOPE '$TMUX_SCOPE' (use session|window)" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "$TMUX_NAMESPACE" ] && [ "$NAMESPACE_MODE" = "inherit" ]; then
+  if [ -n "${TMUX:-}" ]; then
+    TMUX_NAMESPACE="$(tmux display-message -p '#S' 2>/dev/null || true)"
+  fi
+  if [ -z "$TMUX_NAMESPACE" ] && [ -n "${TMUX_BEADS_SESSION:-}" ]; then
+    TMUX_NAMESPACE="$TMUX_BEADS_SESSION"
+  fi
+  if [ -z "$TMUX_NAMESPACE" ] && [ -n "${TMUX_BEADS_MANAGER_TARGET:-}" ]; then
+    TMUX_NAMESPACE="${TMUX_BEADS_MANAGER_TARGET%%:*}"
+  fi
+  if [ -z "$TMUX_NAMESPACE" ] && [ -n "${BEADS_MANAGER_TARGET:-}" ]; then
+    TMUX_NAMESPACE="${BEADS_MANAGER_TARGET%%:*}"
+  fi
+  if [ -z "$TMUX_NAMESPACE" ]; then
+    CLIENT_SESSIONS="$(tmux list-clients -F '#{session_name}' 2>/dev/null | sort -u | awk 'NF')"
+    CLIENT_SESSION_COUNT="$(printf '%s\n' "$CLIENT_SESSIONS" | awk 'NF' | wc -l | tr -d ' ')"
+    if [ "$CLIENT_SESSION_COUNT" = "1" ]; then
+      TMUX_NAMESPACE="$CLIENT_SESSIONS"
+    fi
+  fi
 fi
 
 TMUX_NAME="$REQUESTED_TMUX_NAME"
-if [ "$NAMESPACE_MODE" = "inherit" ] && [ -n "$TMUX_NAMESPACE" ]; then
-  case "$REQUESTED_TMUX_NAME" in
-    "$TMUX_NAMESPACE"|"$TMUX_NAMESPACE${NAMESPACE_DELIM}"*)
-      TMUX_NAME="$REQUESTED_TMUX_NAME"
-      ;;
-    *)
-      TMUX_NAME="${TMUX_NAMESPACE}${NAMESPACE_DELIM}${REQUESTED_TMUX_NAME}"
-      ;;
-  esac
+WINDOW_NAME=""
+if [ "$TMUX_SCOPE" = "session" ]; then
+  if [ "$NAMESPACE_MODE" = "inherit" ] && [ -n "$TMUX_NAMESPACE" ]; then
+    case "$REQUESTED_TMUX_NAME" in
+      "$TMUX_NAMESPACE"|"$TMUX_NAMESPACE${NAMESPACE_DELIM}"*)
+        TMUX_NAME="$REQUESTED_TMUX_NAME"
+        ;;
+      *)
+        TMUX_NAME="${TMUX_NAMESPACE}${NAMESPACE_DELIM}${REQUESTED_TMUX_NAME}"
+        ;;
+    esac
+  fi
+else
+  if [[ "$REQUESTED_TMUX_NAME" == *:* ]]; then
+    TMUX_NAME="$REQUESTED_TMUX_NAME"
+    TMUX_NAMESPACE="${TMUX_NAME%%:*}"
+    WINDOW_NAME="${TMUX_NAME#*:}"
+  else
+    if [ -z "$TMUX_NAMESPACE" ]; then
+      echo "Error: cannot resolve parent tmux session for window scope; set CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE or run inside tmux" >&2
+      exit 1
+    fi
+    TMUX_NAME="${TMUX_NAMESPACE}:${REQUESTED_TMUX_NAME}"
+    WINDOW_NAME="$REQUESTED_TMUX_NAME"
+  fi
 fi
 
 # Resolve working directory to absolute physical path (resolves symlinks)
@@ -59,6 +104,7 @@ mkdir -p /tmp/claude-workers
 # Write metadata
 jq -n \
   --arg tmux_name "$TMUX_NAME" \
+  --arg tmux_scope "$TMUX_SCOPE" \
   --arg requested_tmux_name "$REQUESTED_TMUX_NAME" \
   --arg tmux_namespace "$TMUX_NAMESPACE" \
   --arg session_id "$SESSION_ID" \
@@ -66,6 +112,7 @@ jq -n \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   '{
     tmux_name: $tmux_name,
+    tmux_scope: $tmux_scope,
     requested_tmux_name: $requested_tmux_name,
     tmux_namespace: ($tmux_namespace | if . == "" then null else . end),
     session_id: $session_id,
@@ -74,11 +121,19 @@ jq -n \
   }' \
   > "/tmp/claude-workers/${SESSION_ID}.meta"
 
-# Check for existing tmux session with this name
-if tmux has-session -t "$TMUX_NAME" 2>/dev/null; then
-  echo "Error: tmux session '$TMUX_NAME' already exists" >&2
-  rm -f "/tmp/claude-workers/${SESSION_ID}.meta"
-  exit 1
+# Check for existing tmux target with this name
+if [ "$TMUX_SCOPE" = "session" ]; then
+  if tmux has-session -t "$TMUX_NAME" 2>/dev/null; then
+    echo "Error: tmux session '$TMUX_NAME' already exists" >&2
+    rm -f "/tmp/claude-workers/${SESSION_ID}.meta"
+    exit 1
+  fi
+else
+  if tmux list-panes -t "$TMUX_NAME" >/dev/null 2>&1; then
+    echo "Error: tmux window target '$TMUX_NAME' already exists" >&2
+    rm -f "/tmp/claude-workers/${SESSION_ID}.meta"
+    exit 1
+  fi
 fi
 
 # Propagate approval timeout through tmux to the hook environment
@@ -96,10 +151,17 @@ if ! command -v zsh >/dev/null 2>&1; then
   LAUNCH_SHELL="bash"
 fi
 
-tmux new-session -d -s "$TMUX_NAME" -c "$WORKING_DIR" \
-  -e "CLAUDE_SESSION_DRIVER_APPROVAL_TIMEOUT=$APPROVAL_TIMEOUT" \
-  -e "CLAUDECODE=" \
-  "$LAUNCH_SHELL" -lic "$LAUNCH_CMD"
+if [ "$TMUX_SCOPE" = "session" ]; then
+  tmux new-session -d -s "$TMUX_NAME" -c "$WORKING_DIR" \
+    -e "CLAUDE_SESSION_DRIVER_APPROVAL_TIMEOUT=$APPROVAL_TIMEOUT" \
+    -e "CLAUDECODE=" \
+    "$LAUNCH_SHELL" -lic "$LAUNCH_CMD"
+else
+  tmux new-window -d -t "$TMUX_NAMESPACE" -n "$WINDOW_NAME" -c "$WORKING_DIR" \
+    -e "CLAUDE_SESSION_DRIVER_APPROVAL_TIMEOUT=$APPROVAL_TIMEOUT" \
+    -e "CLAUDECODE=" \
+    "$LAUNCH_SHELL" -lic "$LAUNCH_CMD"
+fi
 
 # Accept the workspace trust dialog (default selection is "Yes, I trust this folder")
 sleep 3
@@ -109,7 +171,11 @@ tmux send-keys -t "$TMUX_NAME" Enter
 WAIT_SCRIPT="$SCRIPT_DIR/wait-for-event.sh"
 if ! bash "$WAIT_SCRIPT" "$SESSION_ID" session_start 30 > /dev/null; then
   echo "Error: Worker session failed to start within 30 seconds" >&2
-  tmux kill-session -t "$TMUX_NAME" 2>/dev/null || true
+  if [ "$TMUX_SCOPE" = "session" ]; then
+    tmux kill-session -t "$TMUX_NAME" 2>/dev/null || true
+  else
+    tmux kill-window -t "$TMUX_NAME" 2>/dev/null || true
+  fi
   rm -f "/tmp/claude-workers/${SESSION_ID}.meta" "/tmp/claude-workers/${SESSION_ID}.events.jsonl"
   exit 1
 fi
@@ -118,6 +184,7 @@ fi
 jq -n \
   --arg session_id "$SESSION_ID" \
   --arg tmux_name "$TMUX_NAME" \
+  --arg tmux_scope "$TMUX_SCOPE" \
   --arg requested_tmux_name "$REQUESTED_TMUX_NAME" \
   --arg events_file "/tmp/claude-workers/${SESSION_ID}.events.jsonl" \
-  '{session_id: $session_id, tmux_name: $tmux_name, requested_tmux_name: $requested_tmux_name, events_file: $events_file}'
+  '{session_id: $session_id, tmux_name: $tmux_name, tmux_scope: $tmux_scope, requested_tmux_name: $requested_tmux_name, events_file: $events_file}'

--- a/scripts/launch-worker.sh
+++ b/scripts/launch-worker.sh
@@ -152,15 +152,21 @@ if ! command -v zsh >/dev/null 2>&1; then
 fi
 
 if [ "$TMUX_SCOPE" = "session" ]; then
-  tmux new-session -d -s "$TMUX_NAME" -c "$WORKING_DIR" \
+  if ! tmux new-session -d -s "$TMUX_NAME" -c "$WORKING_DIR" \
     -e "CLAUDE_SESSION_DRIVER_APPROVAL_TIMEOUT=$APPROVAL_TIMEOUT" \
     -e "CLAUDECODE=" \
-    "$LAUNCH_SHELL" -lic "$LAUNCH_CMD"
+    "$LAUNCH_SHELL" -lic "$LAUNCH_CMD"; then
+    rm -f "/tmp/claude-workers/${SESSION_ID}.meta"
+    exit 1
+  fi
 else
-  tmux new-window -d -t "$TMUX_NAMESPACE" -n "$WINDOW_NAME" -c "$WORKING_DIR" \
+  if ! tmux new-window -d -t "$TMUX_NAMESPACE" -n "$WINDOW_NAME" -c "$WORKING_DIR" \
     -e "CLAUDE_SESSION_DRIVER_APPROVAL_TIMEOUT=$APPROVAL_TIMEOUT" \
     -e "CLAUDECODE=" \
-    "$LAUNCH_SHELL" -lic "$LAUNCH_CMD"
+    "$LAUNCH_SHELL" -lic "$LAUNCH_CMD"; then
+    rm -f "/tmp/claude-workers/${SESSION_ID}.meta"
+    exit 1
+  fi
 fi
 
 # Accept the workspace trust dialog (default selection is "Yes, I trust this folder")

--- a/scripts/launch-worker.sh
+++ b/scripts/launch-worker.sh
@@ -91,10 +91,15 @@ for arg in "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"; do
   LAUNCH_CMD+=" $(printf '%q' "$arg")"
 done
 
+LAUNCH_SHELL="zsh"
+if ! command -v zsh >/dev/null 2>&1; then
+  LAUNCH_SHELL="bash"
+fi
+
 tmux new-session -d -s "$TMUX_NAME" -c "$WORKING_DIR" \
   -e "CLAUDE_SESSION_DRIVER_APPROVAL_TIMEOUT=$APPROVAL_TIMEOUT" \
   -e "CLAUDECODE=" \
-  zsh -lic "$LAUNCH_CMD"
+  "$LAUNCH_SHELL" -lic "$LAUNCH_CMD"
 
 # Accept the workspace trust dialog (default selection is "Yes, I trust this folder")
 sleep 3

--- a/scripts/launch-worker.sh
+++ b/scripts/launch-worker.sh
@@ -139,8 +139,9 @@ fi
 # Propagate approval timeout through tmux to the hook environment
 APPROVAL_TIMEOUT="${CLAUDE_SESSION_DRIVER_APPROVAL_TIMEOUT:-30}"
 
-# Launch worker in detached tmux via interactive zsh so aliases (e.g. `clauded`)
-# are available. Keep --dangerously-skip-permissions to avoid interactive stalls.
+# Launch worker in detached tmux via interactive login shell (prefer zsh, fall
+# back to bash) so aliases (e.g. `clauded`) are available.
+# Keep --dangerously-skip-permissions to avoid interactive stalls.
 LAUNCH_CMD="$CLAUDE_LAUNCH_CMD --session-id $(printf '%q' "$SESSION_ID") --plugin-dir $(printf '%q' "$PLUGIN_DIR") --dangerously-skip-permissions"
 for arg in "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"; do
   LAUNCH_CMD+=" $(printf '%q' "$arg")"

--- a/scripts/send-prompt.sh
+++ b/scripts/send-prompt.sh
@@ -6,12 +6,47 @@ set -euo pipefail
 #
 # Usage: send-prompt.sh <tmux-name> <prompt-text>
 
-TMUX_NAME="${1:?Usage: send-prompt.sh <tmux-name> <prompt-text>}"
+resolve_tmux_name() {
+  local requested="$1"
+
+  if tmux has-session -t "$requested" 2>/dev/null; then
+    printf '%s\n' "$requested"
+    return 0
+  fi
+
+  local meta_file resolved candidate=""
+  local match_count=0
+  while IFS= read -r meta_file; do
+    resolved="$(jq -r --arg requested "$requested" 'select(.requested_tmux_name == $requested) | .tmux_name // empty' "$meta_file" 2>/dev/null || true)"
+    if [ -z "$resolved" ]; then
+      continue
+    fi
+
+    if tmux has-session -t "$resolved" 2>/dev/null; then
+      candidate="$resolved"
+      match_count=$((match_count + 1))
+    fi
+  done < <(find /tmp/claude-workers -maxdepth 1 -type f -name '*.meta' 2>/dev/null | sort)
+
+  if [ "$match_count" -eq 1 ]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  printf '%s\n' "$requested"
+}
+
+TMUX_NAME_INPUT="${1:?Usage: send-prompt.sh <tmux-name> <prompt-text>}"
 PROMPT_TEXT="${2:?Usage: send-prompt.sh <tmux-name> <prompt-text>}"
+TMUX_NAME="$(resolve_tmux_name "$TMUX_NAME_INPUT")"
 
 # Verify tmux session exists
 if ! tmux has-session -t "$TMUX_NAME" 2>/dev/null; then
-  echo "Error: tmux session '$TMUX_NAME' does not exist" >&2
+  if [ "$TMUX_NAME" != "$TMUX_NAME_INPUT" ]; then
+    echo "Error: tmux session '$TMUX_NAME_INPUT' resolved to '$TMUX_NAME', but neither exists" >&2
+  else
+    echo "Error: tmux session '$TMUX_NAME' does not exist" >&2
+  fi
   exit 1
 fi
 

--- a/scripts/send-prompt.sh
+++ b/scripts/send-prompt.sh
@@ -20,11 +20,14 @@ resolve_tmux_name() {
     local session_tmux_name=""
     if [ -f "$session_meta_file" ]; then
       session_tmux_name="$(jq -r '.tmux_name // empty' "$session_meta_file" 2>/dev/null || true)"
-      if [ -n "$session_tmux_name" ] && tmux_target_exists "$session_tmux_name"; then
-        printf '%s\n' "$session_tmux_name"
-        return 0
-      fi
     fi
+
+    if [ -n "$session_tmux_name" ] && tmux_target_exists "$session_tmux_name"; then
+      printf '%s\n' "$session_tmux_name"
+      return 0
+    fi
+
+    return 1
   fi
 
   if tmux_target_exists "$requested"; then
@@ -65,7 +68,10 @@ resolve_tmux_name() {
 TMUX_NAME_INPUT="${1:?Usage: send-prompt.sh <tmux-name> <prompt-text> [session-id]}"
 PROMPT_TEXT="${2:?Usage: send-prompt.sh <tmux-name> <prompt-text> [session-id]}"
 SESSION_ID="${3:-}"
-TMUX_NAME="$(resolve_tmux_name "$TMUX_NAME_INPUT" "$SESSION_ID")"
+if ! TMUX_NAME="$(resolve_tmux_name "$TMUX_NAME_INPUT" "$SESSION_ID")"; then
+  echo "Error: session '$SESSION_ID' does not map to a running tmux target" >&2
+  exit 1
+fi
 
 # Verify tmux target exists
 if ! tmux_target_exists "$TMUX_NAME"; then

--- a/scripts/send-prompt.sh
+++ b/scripts/send-prompt.sh
@@ -51,7 +51,7 @@ TMUX_NAME="$(resolve_tmux_name "$TMUX_NAME_INPUT")"
 # Verify tmux session exists
 if ! tmux has-session -t "$TMUX_NAME" 2>/dev/null; then
   if [ "$TMUX_NAME" != "$TMUX_NAME_INPUT" ]; then
-    echo "Error: tmux session '$TMUX_NAME_INPUT' resolved to '$TMUX_NAME', but neither exists" >&2
+    echo "Error: tmux session '$TMUX_NAME_INPUT' resolved to '$TMUX_NAME', but it no longer exists" >&2
   else
     echo "Error: tmux session '$TMUX_NAME' does not exist" >&2
   fi

--- a/scripts/stop-worker.sh
+++ b/scripts/stop-worker.sh
@@ -1,29 +1,42 @@
 #!/bin/bash
 set -euo pipefail
 
-# Gracefully stops a Claude Code worker session. Sends /exit, waits for
-# session_end event, kills tmux session if needed, and cleans up files.
+# Gracefully stops a Claude Code worker target. Sends /exit, waits for
+# session_end event, kills tmux session/window if needed, and cleans up files.
 #
 # Usage: stop-worker.sh <tmux-name> <session-id>
 
 TMUX_NAME_INPUT="${1:?Usage: stop-worker.sh <tmux-name> <session-id>}"
 SESSION_ID="${2:?Usage: stop-worker.sh <tmux-name> <session-id>}"
 TMUX_NAME="$TMUX_NAME_INPUT"
+TMUX_SCOPE="session"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 META_FILE="/tmp/claude-workers/${SESSION_ID}.meta"
 
+tmux_target_exists() {
+  local target="$1"
+  tmux list-panes -t "$target" >/dev/null 2>&1
+}
+
 # Prefer the tmux_name recorded for this session if the provided name no longer
 # maps directly (for example, when namespace prefixing is enabled).
-if ! tmux has-session -t "$TMUX_NAME" 2>/dev/null && [ -f "$META_FILE" ]; then
+if [ -f "$META_FILE" ]; then
+  META_SCOPE="$(jq -r '.tmux_scope // empty' "$META_FILE" 2>/dev/null || true)"
+  if [ "$META_SCOPE" = "window" ] || [ "$META_SCOPE" = "session" ]; then
+    TMUX_SCOPE="$META_SCOPE"
+  fi
+fi
+
+if ! tmux_target_exists "$TMUX_NAME" && [ -f "$META_FILE" ]; then
   RESOLVED_TMUX_NAME="$(jq -r '.tmux_name // empty' "$META_FILE" 2>/dev/null || true)"
-  if [ -n "$RESOLVED_TMUX_NAME" ] && tmux has-session -t "$RESOLVED_TMUX_NAME" 2>/dev/null; then
+  if [ -n "$RESOLVED_TMUX_NAME" ] && tmux_target_exists "$RESOLVED_TMUX_NAME"; then
     TMUX_NAME="$RESOLVED_TMUX_NAME"
   fi
 fi
 
 # Send /exit command
-if tmux has-session -t "$TMUX_NAME" 2>/dev/null; then
+if tmux_target_exists "$TMUX_NAME"; then
   tmux send-keys -t "$TMUX_NAME" -l '/exit'
   tmux send-keys -t "$TMUX_NAME" Enter
 
@@ -33,9 +46,13 @@ if tmux has-session -t "$TMUX_NAME" 2>/dev/null; then
     sleep 1
   fi
 
-  # Kill tmux session if still running
-  if tmux has-session -t "$TMUX_NAME" 2>/dev/null; then
-    tmux kill-session -t "$TMUX_NAME"
+  # Kill tmux target if still running
+  if tmux_target_exists "$TMUX_NAME"; then
+    if [ "$TMUX_SCOPE" = "window" ]; then
+      tmux kill-window -t "$TMUX_NAME" 2>/dev/null || true
+    else
+      tmux kill-session -t "$TMUX_NAME" 2>/dev/null || true
+    fi
   fi
 fi
 

--- a/scripts/stop-worker.sh
+++ b/scripts/stop-worker.sh
@@ -6,10 +6,21 @@ set -euo pipefail
 #
 # Usage: stop-worker.sh <tmux-name> <session-id>
 
-TMUX_NAME="${1:?Usage: stop-worker.sh <tmux-name> <session-id>}"
+TMUX_NAME_INPUT="${1:?Usage: stop-worker.sh <tmux-name> <session-id>}"
 SESSION_ID="${2:?Usage: stop-worker.sh <tmux-name> <session-id>}"
+TMUX_NAME="$TMUX_NAME_INPUT"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+META_FILE="/tmp/claude-workers/${SESSION_ID}.meta"
+
+# Prefer the tmux_name recorded for this session if the provided name no longer
+# maps directly (for example, when namespace prefixing is enabled).
+if ! tmux has-session -t "$TMUX_NAME" 2>/dev/null && [ -f "$META_FILE" ]; then
+  RESOLVED_TMUX_NAME="$(jq -r '.tmux_name // empty' "$META_FILE" 2>/dev/null || true)"
+  if [ -n "$RESOLVED_TMUX_NAME" ] && tmux has-session -t "$RESOLVED_TMUX_NAME" 2>/dev/null; then
+    TMUX_NAME="$RESOLVED_TMUX_NAME"
+  fi
+fi
 
 # Send /exit command
 if tmux has-session -t "$TMUX_NAME" 2>/dev/null; then

--- a/scripts/stop-worker.sh
+++ b/scripts/stop-worker.sh
@@ -10,6 +10,9 @@ TMUX_NAME_INPUT="${1:?Usage: stop-worker.sh <tmux-name> <session-id>}"
 SESSION_ID="${2:?Usage: stop-worker.sh <tmux-name> <session-id>}"
 TMUX_NAME="$TMUX_NAME_INPUT"
 TMUX_SCOPE="session"
+if [[ "$TMUX_NAME" == *:* ]]; then
+  TMUX_SCOPE="window"
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 META_FILE="/tmp/claude-workers/${SESSION_ID}.meta"

--- a/skills/driving-claude-code-sessions/SKILL.md
+++ b/skills/driving-claude-code-sessions/SKILL.md
@@ -280,10 +280,11 @@ Output is formatted as markdown: thinking in blockquotes, tool calls as code blo
 
 ### Worker Crashes or tmux Dies
 
-If the tmux session disappears, `send-prompt.sh` will fail with "tmux session does not exist." Check before sending:
+If the tmux target disappears, `send-prompt.sh` will fail with "tmux target does not exist." Check before sending:
 ```bash
-if ! tmux has-session -t "$TMUX_NAME" 2>/dev/null; then
-  echo "Worker is gone -- need to relaunch"
+TMUX_TARGET="$TMUX_NAME"
+if ! tmux has-session -t "$TMUX_TARGET" 2>/dev/null; then
+  echo "Worker target is gone -- need to relaunch"
 fi
 ```
 

--- a/skills/driving-claude-code-sessions/SKILL.md
+++ b/skills/driving-claude-code-sessions/SKILL.md
@@ -283,7 +283,7 @@ Output is formatted as markdown: thinking in blockquotes, tool calls as code blo
 If the tmux target disappears, `send-prompt.sh` will fail with "tmux target does not exist." Check before sending:
 ```bash
 TMUX_TARGET="$TMUX_NAME"
-if ! tmux has-session -t "$TMUX_TARGET" 2>/dev/null; then
+if ! tmux list-panes -t "$TMUX_TARGET" >/dev/null 2>&1; then
   echo "Worker target is gone -- need to relaunch"
 fi
 ```

--- a/tests/test-tmux-namespace.sh
+++ b/tests/test-tmux-namespace.sh
@@ -199,7 +199,9 @@ fi
 # --- Test 5: off mode stop-worker cleanup still works ---
 run_test
 if [ -n "$SESSION_ID_OFF" ] && bash "$PLUGIN_DIR/scripts/stop-worker.sh" "$REQUESTED_NAME_OFF" "$SESSION_ID_OFF" >/dev/null 2>&1; then
-  if ! tmux has-session -t "$REQUESTED_NAME_OFF" 2>/dev/null; then
+  if ! tmux has-session -t "$REQUESTED_NAME_OFF" 2>/dev/null && \
+     [ ! -f "/tmp/claude-workers/${SESSION_ID_OFF}.events.jsonl" ] && \
+     [ ! -f "/tmp/claude-workers/${SESSION_ID_OFF}.meta" ]; then
     pass "off mode worker stopped cleanly"
   else
     fail "off mode worker still running after stop"

--- a/tests/test-tmux-namespace.sh
+++ b/tests/test-tmux-namespace.sh
@@ -314,6 +314,14 @@ else
   fail "send-prompt failed to target worker B by session_id"
 fi
 
+# --- Test 8b: invalid session_id must not route to duplicate worker ---
+run_test
+if bash "$PLUGIN_DIR/scripts/send-prompt.sh" "$REQUESTED_NAME_DUP" "duplicate namespace prompt invalid" "missing-session-id" >/dev/null 2>&1; then
+  fail "send-prompt should fail for unknown session_id in duplicate-name mode"
+else
+  pass "send-prompt rejects unknown session_id in duplicate-name mode"
+fi
+
 # --- Test 9: stop-worker cleanup for duplicate session A ---
 run_test
 if [ -n "$SESSION_ID_DUP_A" ] && bash "$PLUGIN_DIR/scripts/stop-worker.sh" "$REQUESTED_NAME_DUP" "$SESSION_ID_DUP_A" >/dev/null 2>&1; then

--- a/tests/test-tmux-namespace.sh
+++ b/tests/test-tmux-namespace.sh
@@ -41,8 +41,7 @@ run_test() {
 wait_for_file() {
   local path="$1"
   local timeout="${2:-50}"
-  local i
-  for i in $(seq 1 "$timeout"); do
+  for _ in $(seq 1 "$timeout"); do
     if [ -s "$path" ]; then
       return 0
     fi

--- a/tests/test-tmux-namespace.sh
+++ b/tests/test-tmux-namespace.sh
@@ -322,6 +322,17 @@ else
   pass "send-prompt rejects unknown session_id in duplicate-name mode"
 fi
 
+# --- Test 8c: duplicate requested name without session_id requires disambiguation ---
+run_test
+DUPLICATE_ERR_FILE="$TMP_DIR/duplicate-no-session.err"
+if bash "$PLUGIN_DIR/scripts/send-prompt.sh" "$REQUESTED_NAME_DUP" "duplicate namespace prompt no session id" >/dev/null 2>"$DUPLICATE_ERR_FILE"; then
+  fail "send-prompt should fail for duplicate names without session_id"
+elif grep -q "workers match requested name '$REQUESTED_NAME_DUP'" "$DUPLICATE_ERR_FILE"; then
+  pass "send-prompt reports disambiguation guidance for duplicate names"
+else
+  fail "send-prompt duplicate-name error did not include disambiguation guidance"
+fi
+
 # --- Test 9: stop-worker cleanup for duplicate session A ---
 run_test
 if [ -n "$SESSION_ID_DUP_A" ] && bash "$PLUGIN_DIR/scripts/stop-worker.sh" "$REQUESTED_NAME_DUP" "$SESSION_ID_DUP_A" >/dev/null 2>&1; then

--- a/tests/test-tmux-namespace.sh
+++ b/tests/test-tmux-namespace.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# Integration-style test for tmux namespacing behavior without launching real Claude.
+#
+# Requirements: tmux, jq
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FAILURES=0
+TESTS=0
+
+TMP_DIR="$(mktemp -d)"
+MOCK_CLAUDE="$TMP_DIR/mock-claude.sh"
+PARENT_SESSION="ns-parent-$$"
+PARENT_SESSION_OFF="ns-parent-off-$$"
+REQUESTED_NAME="worker"
+REQUESTED_NAME_OFF="worker-off"
+TEST_NAMESPACE_DELIM="--"
+LAUNCH_JSON="$TMP_DIR/launch.json"
+LAUNCH_JSON_OFF="$TMP_DIR/launch-off.json"
+
+SESSION_ID=""
+SESSION_ID_OFF=""
+RESOLVED_NAME=""
+RESOLVED_NAME_OFF=""
+
+fail() {
+  echo "FAIL: $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+run_test() {
+  TESTS=$((TESTS + 1))
+}
+
+wait_for_file() {
+  local path="$1"
+  local timeout="${2:-50}"
+  local i
+  for i in $(seq 1 "$timeout"); do
+    if [ -s "$path" ]; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  return 1
+}
+
+cleanup() {
+  tmux kill-session -t "$PARENT_SESSION" 2>/dev/null || true
+  tmux kill-session -t "$PARENT_SESSION_OFF" 2>/dev/null || true
+  if [ -n "$RESOLVED_NAME" ]; then
+    tmux kill-session -t "$RESOLVED_NAME" 2>/dev/null || true
+  fi
+  if [ -n "$RESOLVED_NAME_OFF" ]; then
+    tmux kill-session -t "$RESOLVED_NAME_OFF" 2>/dev/null || true
+  fi
+  if [ -n "$SESSION_ID" ]; then
+    rm -f "/tmp/claude-workers/${SESSION_ID}.events.jsonl" "/tmp/claude-workers/${SESSION_ID}.meta"
+  fi
+  if [ -n "$SESSION_ID_OFF" ]; then
+    rm -f "/tmp/claude-workers/${SESSION_ID_OFF}.events.jsonl" "/tmp/claude-workers/${SESSION_ID_OFF}.meta"
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat > "$MOCK_CLAUDE" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+SESSION_ID=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --session-id)
+      SESSION_ID="${2:-}"
+      shift 2
+      ;;
+    --session-id=*)
+      SESSION_ID="${1#--session-id=}"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$SESSION_ID" ]; then
+  echo "mock-claude: missing --session-id" >&2
+  exit 1
+fi
+
+EVENTS_FILE="/tmp/claude-workers/${SESSION_ID}.events.jsonl"
+printf '{"event":"session_start","session_id":"%s"}\n' "$SESSION_ID" >> "$EVENTS_FILE"
+
+while IFS= read -r line; do
+  if [ "$line" = "/exit" ]; then
+    printf '{"event":"session_end","session_id":"%s"}\n' "$SESSION_ID" >> "$EVENTS_FILE"
+    exit 0
+  fi
+done
+EOF
+chmod +x "$MOCK_CLAUDE"
+
+RUN_INHERIT="$TMP_DIR/run-inherit.sh"
+cat > "$RUN_INHERIT" <<EOF
+#!/bin/bash
+set -euo pipefail
+CLAUDE_SESSION_DRIVER_LAUNCH_CMD="$MOCK_CLAUDE" \
+CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_MODE=inherit \
+CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_DELIM="$TEST_NAMESPACE_DELIM" \
+  bash "$PLUGIN_DIR/scripts/launch-worker.sh" "$REQUESTED_NAME" /tmp > "$LAUNCH_JSON"
+sleep 15
+EOF
+chmod +x "$RUN_INHERIT"
+
+EXPECTED_NAME="${PARENT_SESSION}${TEST_NAMESPACE_DELIM}${REQUESTED_NAME}"
+
+echo "=== Test namespacing in tmux ==="
+
+# --- Test 1: Default inherit mode namespaces worker name ---
+run_test
+if tmux new-session -d -s "$PARENT_SESSION" "$RUN_INHERIT"; then
+  if wait_for_file "$LAUNCH_JSON" 100; then
+    RESOLVED_NAME="$(jq -r '.tmux_name // empty' "$LAUNCH_JSON")"
+    SESSION_ID="$(jq -r '.session_id // empty' "$LAUNCH_JSON")"
+    OUTPUT_REQUESTED="$(jq -r '.requested_tmux_name // empty' "$LAUNCH_JSON")"
+    if [ "$RESOLVED_NAME" = "$EXPECTED_NAME" ] && [ "$OUTPUT_REQUESTED" = "$REQUESTED_NAME" ] && [ -n "$SESSION_ID" ]; then
+      pass "inherit mode prefixes tmux name ($RESOLVED_NAME)"
+    else
+      fail "unexpected launch output: resolved='$RESOLVED_NAME' requested='$OUTPUT_REQUESTED' session='$SESSION_ID'"
+    fi
+  else
+    fail "launch output file not created for inherit mode"
+  fi
+else
+  fail "failed to create parent tmux session"
+fi
+
+# --- Test 2: send-prompt resolves requested name to namespaced session ---
+run_test
+if [ -n "$SESSION_ID" ] && bash "$PLUGIN_DIR/scripts/send-prompt.sh" "$REQUESTED_NAME" "namespace test prompt" >/dev/null 2>&1; then
+  pass "send-prompt accepted requested name in namespaced mode"
+else
+  fail "send-prompt could not resolve requested name in namespaced mode"
+fi
+
+# --- Test 3: stop-worker resolves requested name and cleans up ---
+run_test
+if [ -n "$SESSION_ID" ] && bash "$PLUGIN_DIR/scripts/stop-worker.sh" "$REQUESTED_NAME" "$SESSION_ID" >/dev/null 2>&1; then
+  if ! tmux has-session -t "$EXPECTED_NAME" 2>/dev/null && \
+     [ ! -f "/tmp/claude-workers/${SESSION_ID}.events.jsonl" ] && \
+     [ ! -f "/tmp/claude-workers/${SESSION_ID}.meta" ]; then
+    pass "stop-worker resolved requested name and cleaned up"
+  else
+    fail "stop-worker did not fully clean up namespaced worker"
+  fi
+else
+  fail "stop-worker failed for namespaced worker"
+fi
+
+RUN_OFF="$TMP_DIR/run-off.sh"
+cat > "$RUN_OFF" <<EOF
+#!/bin/bash
+set -euo pipefail
+CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_MODE=off \
+CLAUDE_SESSION_DRIVER_LAUNCH_CMD="$MOCK_CLAUDE" \
+  bash "$PLUGIN_DIR/scripts/launch-worker.sh" "$REQUESTED_NAME_OFF" /tmp > "$LAUNCH_JSON_OFF"
+sleep 15
+EOF
+chmod +x "$RUN_OFF"
+
+echo "=== Test namespace mode off ==="
+
+# --- Test 4: off mode keeps original name ---
+run_test
+if tmux new-session -d -s "$PARENT_SESSION_OFF" "$RUN_OFF"; then
+  if wait_for_file "$LAUNCH_JSON_OFF" 100; then
+    RESOLVED_NAME_OFF="$(jq -r '.tmux_name // empty' "$LAUNCH_JSON_OFF")"
+    SESSION_ID_OFF="$(jq -r '.session_id // empty' "$LAUNCH_JSON_OFF")"
+    if [ "$RESOLVED_NAME_OFF" = "$REQUESTED_NAME_OFF" ] && [ -n "$SESSION_ID_OFF" ]; then
+      pass "off mode keeps tmux name unmodified"
+    else
+      fail "off mode produced unexpected name '$RESOLVED_NAME_OFF'"
+    fi
+  else
+    fail "launch output file not created for off mode"
+  fi
+else
+  fail "failed to create off-mode parent tmux session"
+fi
+
+# --- Test 5: off mode stop-worker cleanup still works ---
+run_test
+if [ -n "$SESSION_ID_OFF" ] && bash "$PLUGIN_DIR/scripts/stop-worker.sh" "$REQUESTED_NAME_OFF" "$SESSION_ID_OFF" >/dev/null 2>&1; then
+  if ! tmux has-session -t "$REQUESTED_NAME_OFF" 2>/dev/null; then
+    pass "off mode worker stopped cleanly"
+  else
+    fail "off mode worker still running after stop"
+  fi
+else
+  fail "off mode stop-worker failed"
+fi
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [ "$FAILURES" -gt 0 ]; then
+  exit 1
+fi
+echo "tmux namespace tests complete!"


### PR DESCRIPTION
## Summary
Add tmux namespace inheritance so worker sessions launched from inside tmux are grouped under the coordinator session name, while preserving compatibility for existing requested names.

## Changes
- `launch-worker.sh`
  - Added namespace inheritance logic with env controls:
    - `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_MODE` (`inherit`/`off`)
    - `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE`
    - `CLAUDE_SESSION_DRIVER_TMUX_NAMESPACE_DELIM`
  - Added `requested_tmux_name` and optional `tmux_namespace` metadata fields.
  - Added `CLAUDE_SESSION_DRIVER_LAUNCH_CMD` override (default remains `claude`).
- `send-prompt.sh`
  - Resolves a requested tmux name to the active namespaced session via worker metadata.
- `stop-worker.sh`
  - Falls back to session metadata for tmux resolution when direct lookup fails.
- `tests/test-integration.sh`
  - Updated to validate requested vs resolved tmux name handling.
- `tests/test-tmux-namespace.sh` (new)
  - Adds focused coverage for namespace inheritance, requested-name prompt routing, stop/cleanup, and namespace-off mode using a mock launcher.
- `README.md`
  - Documented namespacing behavior and env controls.

## Testing
- `bash tests/test-approve-tool.sh`
- `bash tests/test-emit-event.sh`
- `bash tests/test-read-events.sh`
- `bash tests/test-wait-for-event.sh`
- `bash tests/test-tmux-namespace.sh`
- `bash tests/test-integration.sh --dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Namespace-aware tmux support for workers (inherit|off modes, window/session scope). Launch returns requested and resolved tmux names plus tmux_scope for follow-ups.
  * send-prompt accepts an optional session_id for deterministic targeting when names collide.

* **Bug Fixes**
  * Improved name-resolution, clearer error messages, and stop-worker can fall back to per-session metadata for reliable cleanup.

* **Documentation**
  * Updated docs, examples, and usage texts to reflect namespace behavior and new usage signatures.

* **Tests**
  * New integration tests covering namespaces, resolution, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->