### PR TITLE
fix: stop emit-event hook from hanging on empty stdin

### DIFF
--- a/hooks/emit-event.sh
+++ b/hooks/emit-event.sh
@@ -7,7 +7,12 @@ set -euo pipefail
 #
 # Only activates for worker sessions launched by the session driver.
 
-INPUT=$(cat)
+# Claude sometimes invokes the hook without piping event JSON. Read one JSON
+# line and exit quietly if stdin never produces data instead of blocking
+# forever behind a hanging cat process.
+if ! IFS= read -r -t "${CLAUDE_SESSION_DRIVER_STDIN_TIMEOUT:-1}" INPUT; then
+  exit 0
+fi
 
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id')
 

--- a/tests/test-emit-event.sh
+++ b/tests/test-emit-event.sh
@@ -38,6 +38,21 @@ make_worker() {
   echo '{"tmux_name":"test","session_id":"'"$sid"'"}' > "$EVENT_DIR/${sid}.meta"
 }
 
+cleanup_blocking_stdin_test() {
+  if [ -n "${EMIT_PID:-}" ] && kill -0 "$EMIT_PID" 2>/dev/null; then
+    kill "$EMIT_PID" 2>/dev/null || true
+    wait "$EMIT_PID" 2>/dev/null || true
+  fi
+  if [ -n "${WRITER_PID:-}" ] && kill -0 "$WRITER_PID" 2>/dev/null; then
+    kill "$WRITER_PID" 2>/dev/null || true
+    wait "$WRITER_PID" 2>/dev/null || true
+  fi
+  if [ -n "${FIFO_PATH:-}" ] && [ -p "$FIFO_PATH" ]; then
+    rm -f "$FIFO_PATH"
+  fi
+  unset EMIT_PID WRITER_PID FIFO_PATH
+}
+
 # --- Test: Non-worker sessions are silently skipped ---
 echo "Test: Non-worker sessions are silently skipped"
 setup
@@ -53,6 +68,36 @@ if [ ! -f "$EVENT_FILE" ]; then
 else
   fail "non-worker skip" "event file should not exist"
 fi
+
+# --- Test: Missing stdin does not hang forever ---
+echo "Test: Missing stdin exits quickly without hanging"
+setup
+SESSION_ID="test-session-no-stdin"
+make_worker "$SESSION_ID"
+FIFO_PATH=$(mktemp -u "$EVENT_DIR/test-fifo.XXXXXX")
+mkfifo "$FIFO_PATH"
+
+# Keep the pipe open without writing any data. This reproduces the hanging
+# stdin case that previously left cat processes around forever.
+(
+  exec 3>"$FIFO_PATH"
+  sleep 5
+) &
+WRITER_PID=$!
+
+bash "$EMIT_EVENT" < "$FIFO_PATH" > /dev/null &
+EMIT_PID=$!
+
+sleep 2
+
+if kill -0 "$EMIT_PID" 2>/dev/null; then
+  fail "missing stdin timeout" "emit-event.sh should have exited instead of hanging on stdin"
+else
+  wait "$EMIT_PID" 2>/dev/null || true
+  pass "emit-event.sh exits when stdin stays open without data"
+fi
+
+cleanup_blocking_stdin_test
 
 # --- Test: SessionStart creates file with correct JSONL ---
 echo "Test: SessionStart creates file with correct JSONL"


### PR DESCRIPTION
## Summary
- replace the unbounded `cat` read in `hooks/emit-event.sh` with a timed single-line read
- exit quietly when Claude invokes the hook without piping event JSON instead of leaving the hook process hanging
- add a regression test that keeps stdin open without sending data and verifies the hook exits

## Validation
- `bash tests/test-emit-event.sh`
- `bash tests/test-read-events.sh`
- `bash tests/test-wait-for-event.sh`

Closes #9