### PR TITLE
hooks/approve-tool.sh: include hookEventName field in PreToolUse output (Claude Code spec compliance)

### DIFF
--- a/hooks/approve-tool.sh
+++ b/hooks/approve-tool.sh
@@ -73,13 +73,13 @@ rm -f "$PENDING_FILE" "$DECISION_FILE"
 # Map decision to hook output
 case "$DECISION" in
   allow)
-    echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
     ;;
   deny)
-    echo '{"hookSpecificOutput":{"permissionDecision":"deny"}}'
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"}}'
     ;;
   *)
     # Unknown decision, default to allow
-    echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
     ;;
 esac


### PR DESCRIPTION
## Summary

Claude Code's PreToolUse hook spec requires the `hookEventName` field in the
`hookSpecificOutput` JSON. Without it, the auto-approve decision is silently
ignored and the worker hangs at every tool prompt.

This PR adds `"hookEventName":"PreToolUse"` to all three JSON outputs in
`hooks/approve-tool.sh` (allow / deny / default).

## Repro

1. Install `claude-session-driver` v1.0.1 (current release).
2. Launch a worker via `scripts/launch-worker.sh`.
3. Send any prompt that triggers a tool call (Read, Bash, etc.).
4. Observe: worker hangs at the permission prompt indefinitely. The
   approve-tool hook fires and emits its JSON, but Claude Code rejects the
   output because `hookEventName` is missing, falling back to interactive
   approval which never comes (the session is detached).

## Fix

`hooks/approve-tool.sh`:

```diff
@@ -73,13 +73,13 @@
 # Map decision to hook output
 case "$DECISION" in
   allow)
-    echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
     ;;
   deny)
-    echo '{"hookSpecificOutput":{"permissionDecision":"deny"}}'
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"}}'
     ;;
   *)
     # Unknown decision, default to allow
-    echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
     ;;
 esac
```

## Discovery context

Found 2026-04-30 in the `autopilot` project (https://github.com/RazzaBot/autopilot)
during an `ap002-1` spec engine run. The dispatcher framed it as "non-blocking
worth fixing later" — operator correction triggered an inline fix.

## Test plan

- [ ] On a fresh checkout: launch worker, send `ls /tmp` prompt, verify auto-approve fires (no hang).
- [ ] No regression on the `tests/test-approve-tool.sh` suite (output JSON shape change doesn't break the existing assertions if they're shape-loose; if they're strict, suggest updating to assert on the new shape).

## Backwards compatibility

The added field is additive — older Claude Code versions that didn't require
`hookEventName` ignored extra fields silently, so this is forward-compatible
across the spec change.
