### PR TITLE
feat(csd): add `adopt` to recover workers after a reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `csd adopt <tmux-name> <cwd> <session-id> [-- claude-args...]` — re-adopt an
+  existing Claude session as a driveable worker via `claude --resume`. Restores
+  a worker after a reboot/crash wiped `/tmp/claude-workers` while the session
+  transcript survived under `~/.claude/projects`. Pre-writes the meta keyed by
+  the (resume-preserved) session id so the worker emits events normally, then
+  writes the standard shim. If a tmux session of that name already exists (e.g.
+  restored by tmux-resurrect/continuum) it respawns the pane in place to
+  preserve the restored layout; otherwise it opens a new one.
+- `examples/recover-workers.sh` — bulk recovery built on `csd adopt`: derives
+  each worker's session id from a tmux-resurrect snapshot (or live tmux) and the
+  `~/.claude/projects` transcripts, with `--dry-run`, `--manifest` pins for
+  cwd-shared sessions, and `--pattern` filtering.
+
+### Internal
+- Extracted `_await_session_start` and `_write_worker_shim` helpers shared by
+  `cmd_launch` and `cmd_adopt` (no behavior change to `launch`).
+
 ## [3.0.0] - 2026-05-18
 
 ### Breaking changes

--- a/examples/recover-workers.sh
+++ b/examples/recover-workers.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+set -euo pipefail
+
+# recover-workers.sh — reference implementation of bulk worker recovery after a
+# reboot, built on `csd adopt`.
+#
+# THE PROBLEM
+#   Worker runtime state (the meta/events/shim files under /tmp/claude-workers)
+#   lives in /tmp, which macOS clears on reboot. The tmux panes die too. But the
+#   *conversations* survive: Claude Code persists every session transcript under
+#   ~/.claude/projects/<encoded-cwd>/<session-id>.jsonl. `csd adopt` can bring a
+#   transcript back as a live, driveable worker via `claude --resume`. This
+#   script finds each worker's transcript and calls `csd adopt` for it.
+#
+# WHERE THE WORKER LIST COMES FROM
+#   --snapshot FILE : a tmux-resurrect save file (e.g. the one tmux-continuum
+#                     wrote before the reboot, typically under
+#                     ~/.local/share/tmux/resurrect/ or ~/.tmux/resurrect/).
+#                     This is the natural pairing with tmux-continuum's
+#                     @continuum-boot: continuum restores your layout, then this
+#                     re-adopts each restored pane in place.
+#   (default)       : the live tmux server's current sessions.
+#
+# HOW THE SESSION ID IS FOUND
+#   For each (tmux-name, cwd), the cwd is encoded the way Claude Code names its
+#   project dirs (every /, . and _ becomes -), and the NEWEST *.jsonl in that
+#   dir is taken as the worker's session. This is a heuristic: it assumes one
+#   worker per cwd. When two workers shared a cwd, it can't disambiguate — it
+#   prints the candidates and skips, so you can pass an explicit manifest line.
+#
+# SHARED-CWD AMBIGUITY
+#   The newest-in-dir heuristic fails when two sessions share a cwd — most
+#   commonly the repo root, used by BOTH a worker and your driver/PM session.
+#   There the newest transcript is usually the driver's, not the worker's.
+#   Pin those explicitly with --manifest: a file of `tmux_name<TAB>session_id`
+#   lines (an optional third <TAB>cwd column overrides the derived cwd). Manifest
+#   entries always win over auto-derivation. ALWAYS --dry-run first and eyeball
+#   the UUIDs before applying.
+#
+# USAGE
+#   recover-workers.sh [--dry-run] [--snapshot FILE] [--manifest FILE] \
+#                      [--pattern SUBSTR] [-- extra claude args...]
+#
+#   --dry-run         : print the `csd adopt` commands instead of running them.
+#   --snapshot FILE   : derive the worker list from a tmux-resurrect save file.
+#   --manifest FILE   : explicit name->session-id (->cwd) pins; win over derive.
+#   --pattern SUBSTR  : only recover workers whose tmux name contains SUBSTR.
+#   -- <args>         : forwarded to each `csd adopt` (e.g. -- --model sonnet).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
+
+DRY_RUN=0
+SNAPSHOT=""
+MANIFEST=""
+PATTERN=""
+EXTRA=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)  DRY_RUN=1; shift ;;
+    --snapshot) SNAPSHOT="${2:?--snapshot needs a file}"; shift 2 ;;
+    --manifest) MANIFEST="${2:?--manifest needs a file}"; shift 2 ;;
+    --pattern)  PATTERN="${2:?--pattern needs a value}"; shift 2 ;;
+    --)         shift; EXTRA=("$@"); break ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$MANIFEST" ] && [ ! -f "$MANIFEST" ] && { echo "Manifest not found: $MANIFEST" >&2; exit 1; }
+
+# manifest_lookup <name> <field:2=session_id|3=cwd> — echoes value or empty.
+manifest_lookup() {
+  [ -n "$MANIFEST" ] || return 0
+  awk -F'\t' -v n="$1" -v f="$2" '$1==n{print $f; exit}' "$MANIFEST"
+}
+
+# Claude Code encodes a cwd into its project-dir name by replacing every
+# '/', '.' and '_' with '-'. (e.g. /a/b/.claude/c_d -> -a-b--claude-c-d)
+encode_cwd() { echo "$1" | sed 's#[/._]#-#g'; }
+
+# Emit "tmux_name<TAB>cwd" lines for the workers to recover.
+list_workers() {
+  if [ -n "$SNAPSHOT" ]; then
+    [ -f "$SNAPSHOT" ] || { echo "Snapshot not found: $SNAPSHOT" >&2; exit 1; }
+    # resurrect 'pane' lines are tab-separated; the cwd is the field that
+    # starts with ':/'. Print one row per session (first pane wins).
+    awk -F'\t' '$1=="pane"{
+      for(i=1;i<=NF;i++) if($i ~ /^:\//){ if(!seen[$2]++) print $2"\t"substr($i,2); break }
+    }' "$SNAPSHOT"
+  else
+    tmux list-sessions -F '#{session_name}' 2>/dev/null | while read -r s; do
+      cwd=$(tmux display-message -p -t "$s" '#{pane_current_path}' 2>/dev/null || true)
+      [ -n "$cwd" ] && printf '%s\t%s\n' "$s" "$cwd"
+    done
+  fi
+}
+
+recovered=0 skipped=0
+while IFS=$'\t' read -r name cwd; do
+  [ -n "$name" ] || continue
+  [ -n "$PATTERN" ] && [[ "$name" != *"$PATTERN"* ]] && continue
+
+  # An explicit manifest cwd (col 3) overrides the derived one.
+  m_cwd=$(manifest_lookup "$name" 3)
+  [ -n "$m_cwd" ] && cwd="$m_cwd"
+
+  # Session id: manifest pin (col 2) wins; otherwise newest transcript in the
+  # cwd's project dir. Pinning is how you handle a cwd shared by >1 session.
+  uuid=$(manifest_lookup "$name" 2)
+  if [ -z "$uuid" ]; then
+    proj="$HOME/.claude/projects/$(encode_cwd "$cwd")"
+    if [ ! -d "$proj" ]; then
+      echo "SKIP  $name — no transcripts dir for cwd ($cwd)" >&2
+      skipped=$((skipped+1)); continue
+    fi
+    # (avoid mapfile — macOS /bin/bash is 3.2)
+    jsonls=()
+    while IFS= read -r line; do jsonls+=("$line"); done \
+      < <(ls -t "$proj"/*.jsonl 2>/dev/null)
+    if [ "${#jsonls[@]}" -eq 0 ]; then
+      echo "SKIP  $name — no transcripts in $proj" >&2
+      skipped=$((skipped+1)); continue
+    fi
+    uuid=$(basename "${jsonls[0]}" .jsonl)
+    if [ "${#jsonls[@]}" -gt 1 ]; then
+      echo "WARN  $name — ${#jsonls[@]} transcripts in cwd; picked newest ($uuid)." \
+           "If this cwd is shared by another session, pin via --manifest." >&2
+    fi
+  fi
+
+  ADOPT=(adopt "$name" "$cwd" "$uuid")
+  [ "${#EXTRA[@]}" -gt 0 ] && ADOPT+=(-- "${EXTRA[@]}")
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '%q' "$CSD"; printf ' %q' "${ADOPT[@]}"; printf '\n'
+  elif "$CSD" "${ADOPT[@]}" >/dev/null; then
+    echo "OK    $name  <-  $uuid"
+    recovered=$((recovered+1))
+  else
+    echo "FAIL  $name  ($uuid)" >&2
+    skipped=$((skipped+1))
+  fi
+done < <(list_workers)
+
+echo "" >&2
+echo "recovered: $recovered, skipped: $skipped" >&2

--- a/skills/driving-claude-code-sessions/SKILL.md
+++ b/skills/driving-claude-code-sessions/SKILL.md
@@ -24,6 +24,7 @@ The shim path is deterministic: if you pick a memorable tmux name at launch, you
 The CLI lives at `<skill>/scripts/csd`. Three top-level subcommands need the skill path:
 
 - `csd launch <tmux-name> <cwd> [-- claude-args...]` — bootstrap a worker
+- `csd adopt <tmux-name> <cwd> <session-id> [-- claude-args...]` — re-adopt an existing Claude session as a worker (see [Recovering workers](#recovering-workers-after-a-reboot))
 - `csd list [--all]` — enumerate workers
 - `csd grant-consent` — one-time consent for `--dangerously-skip-permissions`
 
@@ -152,6 +153,7 @@ $SKILL/csd list api                  # substring filter on tmux name
 
 ```
 csd launch <tmux-name> <cwd> [-- claude-args...]
+csd adopt <tmux-name> <cwd> <session-id> [-- claude-args...]
 csd list [--all] [<pattern>]
 csd grant-consent
 
@@ -204,6 +206,19 @@ $SKILL/csd launch impl ~/proj
 ### Worker crashes mid-turn
 
 `wait-for-turn` matches `stop` OR `session_end`, so it returns when the worker dies. Call `status` afterward: if it's `gone`, the worker crashed.
+
+### Recovering workers after a reboot
+
+Worker runtime state (the `meta`/`events`/`shim` files under `/tmp/claude-workers`) lives in `/tmp`, which macOS clears on reboot — and the tmux panes die with it. But the *conversations* survive: Claude Code persists each session transcript at `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`. `csd adopt` brings one back as a live, driveable worker:
+
+```bash
+$SKILL/csd adopt my-task /path/to/project <session-id>
+# stdout: /tmp/claude-workers/bin/my-task   (same shim contract as launch)
+```
+
+`adopt` pre-writes the meta keyed by `<session-id>`, starts `claude --resume <session-id>` (which preserves the id, so the worker emits events normally), and writes the shim — so the resumed conversation is fully driveable (`converse`/`status`/`read-turn`/…), with all prior context intact. If a tmux session of that name already exists (e.g. restored by [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) / tmux-continuum), `adopt` respawns its pane *in place*, preserving the restored layout; otherwise it opens a new one.
+
+Find a worker's `<session-id>` from its working directory: the newest `*.jsonl` in `~/.claude/projects/<cwd with every / . _ replaced by ->`. For bulk recovery (e.g. pairing with tmux-continuum's `@continuum-boot`), `examples/recover-workers.sh` reads a tmux-resurrect snapshot, derives each id, and calls `adopt` per worker — run it with `--dry-run` first. Note: workers are restored as resumed sessions, not their original tool/MCP state; re-pass any launch args (e.g. `-- --model …`) you depended on.
 
 ### Lost the shim path
 

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -4,7 +4,7 @@ set -euo pipefail
 # csd — single CLI for claude-session-driver. Dispatches to subcommand
 # functions defined below. Sources _lib.sh for shared helpers.
 #
-# Top-level subcommands (no --worker): launch, list, grant-consent
+# Top-level subcommands (no --worker): launch, adopt, list, grant-consent
 # Per-worker subcommands (require --worker): converse, send, wait-for-turn,
 #   status, read-events, read-turn, stop, handoff, session-id, events-file
 #
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(dirname "$CSD_PATH")"
 source "$SCRIPT_DIR/_lib.sh"
 
 # Constants / arrays
-TOP_LEVEL_SUBS=(launch list grant-consent help)
+TOP_LEVEL_SUBS=(launch adopt list grant-consent help)
 PER_WORKER_SUBS=(converse send wait-for-turn status read-events read-turn \
                  stop handoff session-id events-file)
 
@@ -37,6 +37,14 @@ subcommands. \`csd stop\` removes the shim along with the worker's state.
 Top-level subcommands:
   launch <tmux-name> <cwd> [-- claude-args...]
                        Bootstrap a worker; shim path on stdout, panel on stderr
+  adopt <tmux-name> <cwd> <session-id> [-- claude-args...]
+                       Re-adopt an existing Claude session as a driveable
+                       worker via \`claude --resume <session-id>\`. Restores a
+                       worker after a reboot/crash wiped /tmp/claude-workers
+                       while the conversation transcript survived. If a tmux
+                       session named <tmux-name> already exists (e.g. restored
+                       by tmux-resurrect), respawns its pane in place; else
+                       opens a new one. Shim path on stdout, panel on stderr
   list [--all] [<pattern>]
                        Enumerate workers (default: skip workers whose tmux is
                        gone). Optional pattern filters by tmux-name substring
@@ -501,6 +509,72 @@ the session.
 EOF
 }
 
+# _await_session_start <tmux_name> <session_id>
+# After claude has been started in the worker's tmux session, accept any
+# trust-folder dialog, then block until the plugin's SessionStart hook records a
+# session_start event (proof the worker is live and emitting). On failure: dump
+# the pane, tear down the tmux session, remove the meta + events, return 1.
+# Shared by cmd_launch and cmd_adopt.
+_await_session_start() {
+  local tmux_name="$1" session_id="$2"
+  local event_file="/tmp/claude-workers/${session_id}.events.jsonl"
+
+  # Trust-dialog accept (content-aware) — same logic as legacy launch-worker.sh
+  local trust_deadline=$((SECONDS + 5))
+  while [ "$SECONDS" -lt "$trust_deadline" ]; do
+    local pane_text
+    pane_text=$(tmux capture-pane -t "$tmux_name" -p 2>/dev/null || true)
+    if echo "$pane_text" | grep -qF "trust this folder"; then
+      tmux send-keys -t "$tmux_name" Enter
+      break
+    fi
+    if [ -f "$event_file" ] \
+       && grep -q '"event":"session_start"' "$event_file" 2>/dev/null; then
+      break
+    fi
+    sleep 0.25
+  done
+
+  # Wait for session_start (inline poll — cmd_wait_for_turn only matches stop/session_end)
+  local deadline=$((SECONDS + 30))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if [ -f "$event_file" ] && grep -q '"event":"session_start"' "$event_file"; then
+      return 0
+    fi
+    sleep 0.5
+  done
+
+  local pane
+  pane=$(tmux capture-pane -t "$tmux_name" -p 2>/dev/null | sed -e 's/[[:space:]]*$//' -e '/^$/d' | tail -20 || true)
+  {
+    echo "Error: Worker session failed to start within 30 seconds"
+    if [ -n "$pane" ]; then
+      echo ""
+      echo "Last visible content in the worker pane:"
+      echo "----------"
+      echo "$pane"
+      echo "----------"
+    fi
+  } >&2
+  tmux kill-session -t "$tmux_name" 2>/dev/null || true
+  rm -f "/tmp/claude-workers/${session_id}.meta" "$event_file"
+  return 1
+}
+
+# _write_worker_shim <tmux_name>
+# Write the per-worker shim that bakes in --worker and execs csd; echo its path.
+# Shared by cmd_launch and cmd_adopt.
+_write_worker_shim() {
+  local tmux_name="$1"
+  local shim_path="/tmp/claude-workers/bin/$tmux_name"
+  cat > "$shim_path" <<EOF
+#!/bin/bash
+exec "$CSD_PATH" --worker "$tmux_name" "\$@"
+EOF
+  chmod +x "$shim_path"
+  echo "$shim_path"
+}
+
 cmd_launch() {
   local tmux_name="${1:?Usage: launch <tmux-name> <cwd> [-- claude-args...]}"
   local working_dir="${2:?Usage: launch <tmux-name> <cwd> [-- claude-args...]}"
@@ -572,59 +646,12 @@ EOF
       --disallowed-tools AskUserQuestion \
       "${extra_args[@]+"${extra_args[@]}"}"
 
-  # Trust-dialog accept (content-aware) — same logic as legacy launch-worker.sh
-  local trust_deadline=$((SECONDS + 5))
-  while [ "$SECONDS" -lt "$trust_deadline" ]; do
-    local pane_text
-    pane_text=$(tmux capture-pane -t "$tmux_name" -p 2>/dev/null || true)
-    if echo "$pane_text" | grep -qF "trust this folder"; then
-      tmux send-keys -t "$tmux_name" Enter
-      break
-    fi
-    if [ -f "/tmp/claude-workers/${session_id}.events.jsonl" ] \
-       && grep -q '"event":"session_start"' "/tmp/claude-workers/${session_id}.events.jsonl" 2>/dev/null; then
-      break
-    fi
-    sleep 0.25
-  done
+  # Accept any trust dialog and block until the worker emits session_start.
+  _await_session_start "$tmux_name" "$session_id" || return 1
 
-  # Wait for session_start (inline poll — cmd_wait_for_turn only matches stop/session_end)
   local event_file="/tmp/claude-workers/${session_id}.events.jsonl"
-  local deadline=$((SECONDS + 30))
-  local started=0
-  while [ "$SECONDS" -lt "$deadline" ]; do
-    if [ -f "$event_file" ] && grep -q '"event":"session_start"' "$event_file"; then
-      started=1
-      break
-    fi
-    sleep 0.5
-  done
-
-  if [ "$started" -eq 0 ]; then
-    local pane
-    pane=$(tmux capture-pane -t "$tmux_name" -p 2>/dev/null | sed -e 's/[[:space:]]*$//' -e '/^$/d' | tail -20 || true)
-    {
-      echo "Error: Worker session failed to start within 30 seconds"
-      if [ -n "$pane" ]; then
-        echo ""
-        echo "Last visible content in the worker pane:"
-        echo "----------"
-        echo "$pane"
-        echo "----------"
-      fi
-    } >&2
-    tmux kill-session -t "$tmux_name" 2>/dev/null || true
-    rm -f "/tmp/claude-workers/${session_id}.meta" "$event_file"
-    return 1
-  fi
-
-  # Write the shim
-  local shim_path="/tmp/claude-workers/bin/$tmux_name"
-  cat > "$shim_path" <<EOF
-#!/bin/bash
-exec "$CSD_PATH" --worker "$tmux_name" "\$@"
-EOF
-  chmod +x "$shim_path"
+  local shim_path
+  shim_path="$(_write_worker_shim "$tmux_name")"
 
   # Build a safely-quoted reproduce line so args with whitespace survive.
   local reproduce_args=""
@@ -642,6 +669,120 @@ EOF
     echo "  cwd:        $working_dir"
     echo "  events:     $event_file"
     echo "  reproduce: $(printf '%q' "$CSD_PATH") launch${reproduce_args}"
+  } >&2
+}
+
+cmd_adopt() {
+  local tmux_name="${1:?Usage: adopt <tmux-name> <cwd> <session-id> [-- claude-args...]}"
+  local working_dir="${2:?Usage: adopt <tmux-name> <cwd> <session-id> [-- claude-args...]}"
+  local session_id="${3:?Usage: adopt <tmux-name> <cwd> <session-id> [-- claude-args...]}"
+  shift 3
+  # Skip a leading -- separator if present
+  if [ "${1:-}" = "--" ]; then shift; fi
+  local extra_args=("$@")
+
+  # Capture the invocation for the reproduce line
+  local original_argv=("$tmux_name" "$working_dir" "$session_id")
+  if [ "${#extra_args[@]}" -gt 0 ]; then
+    original_argv+=("--" "${extra_args[@]}")
+  fi
+
+  # Resolve plugin root (three levels above scripts/)
+  local plugin_dir
+  plugin_dir="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+  # Resolve cwd to absolute, follow symlinks
+  if [ ! -d "$working_dir" ]; then
+    echo "Error: cwd '$working_dir' does not exist" >&2
+    return 1
+  fi
+  working_dir="$(cd "$working_dir" && pwd -P)"
+
+  # Basic session-id sanity (UUID-ish: hex + dashes). Claude resolves the actual
+  # transcript on resume; this only guards obvious mistakes like passing a path.
+  if ! echo "$session_id" | grep -qE '^[0-9a-fA-F][0-9a-fA-F-]{7,}$'; then
+    echo "Error: '$session_id' does not look like a Claude session id" >&2
+    return 1
+  fi
+
+  # Consent check
+  local consent_file="$HOME/.claude/.claude-session-driver-consent"
+  if [ ! -f "$consent_file" ]; then
+    cat >&2 <<EOF
+Error: claude-session-driver requires one-time consent before launching workers.
+Run: $CSD_PATH grant-consent
+EOF
+    return 1
+  fi
+
+  mkdir -p /tmp/claude-workers /tmp/claude-workers/bin
+
+  # `claude --resume <id>` preserves the session id, so the worker's runtime
+  # session_id equals the id we were handed. Pre-write the meta keyed by it
+  # *before* starting claude: the SessionStart hook (emit-event) only records
+  # events once a meta file for that session_id exists.
+  local invocation_json
+  invocation_json=$(printf '%s\n' "${original_argv[@]}" | jq -R . | jq -s .)
+  jq -n \
+    --arg tmux_name "$tmux_name" \
+    --arg session_id "$session_id" \
+    --arg cwd "$working_dir" \
+    --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    --argjson invocation "$invocation_json" \
+    '{tmux_name: $tmux_name, session_id: $session_id, cwd: $cwd, started_at: $started_at, invocation: $invocation}' \
+    > "/tmp/claude-workers/${session_id}.meta"
+
+  # Start (or respawn) the worker with --resume instead of --session-id.
+  local claude_bin="${CSD_CLAUDE_BIN:-claude}"
+  local mode
+  if tmux has-session -t "$tmux_name" 2>/dev/null; then
+    # A pane with this name already exists — e.g. restored by tmux-resurrect /
+    # tmux-continuum after a reboot. Respawn it in place so the user's restored
+    # window layout is preserved; -k kills whatever dead command the restore left.
+    mode="respawned existing pane"
+    tmux respawn-pane -k -t "$tmux_name" -c "$working_dir" \
+      -e "CLAUDE_CODE_SSE_PORT=" \
+      -e "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=" \
+      "$claude_bin" --resume "$session_id" --plugin-dir "$plugin_dir" \
+        --settings '{"skipDangerousModePermissionPrompt":true}' \
+        --dangerously-skip-permissions \
+        --disallowed-tools AskUserQuestion \
+        "${extra_args[@]+"${extra_args[@]}"}"
+  else
+    mode="opened new pane"
+    tmux new-session -d -s "$tmux_name" -c "$working_dir" \
+      -e "CLAUDE_CODE_SSE_PORT=" \
+      -e "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=" \
+      "$claude_bin" --resume "$session_id" --plugin-dir "$plugin_dir" \
+        --settings '{"skipDangerousModePermissionPrompt":true}' \
+        --dangerously-skip-permissions \
+        --disallowed-tools AskUserQuestion \
+        "${extra_args[@]+"${extra_args[@]}"}"
+  fi
+
+  # Accept any trust dialog and block until the worker emits session_start.
+  _await_session_start "$tmux_name" "$session_id" || return 1
+
+  local event_file="/tmp/claude-workers/${session_id}.events.jsonl"
+  local shim_path
+  shim_path="$(_write_worker_shim "$tmux_name")"
+
+  # Build a safely-quoted reproduce line so args with whitespace survive.
+  local reproduce_args=""
+  local arg
+  for arg in "${original_argv[@]}"; do
+    reproduce_args+=" $(printf '%q' "$arg")"
+  done
+
+  # Output: shim path on stdout, panel on stderr
+  echo "$shim_path"
+  {
+    echo "Worker adopted ($mode)."
+    echo "  tmux:       $tmux_name"
+    echo "  session_id: $session_id"
+    echo "  cwd:        $working_dir"
+    echo "  events:     $event_file"
+    echo "  reproduce: $(printf '%q' "$CSD_PATH") adopt${reproduce_args}"
   } >&2
 }
 
@@ -744,5 +885,6 @@ case "$SUB" in
   converse)         cmd_converse "$@" ;;
   handoff)          cmd_handoff ;;
   launch)           cmd_launch "$@" ;;
+  adopt)            cmd_adopt "$@" ;;
   stop)             cmd_stop ;;
 esac

--- a/tests/test-csd-adopt.sh
+++ b/tests/test-csd-adopt.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -euo pipefail
+
+# Tests for `csd adopt` — re-adopting an existing Claude session (by id) as a
+# driveable worker via `claude --resume`. Covers: stdout/shim contract, meta
+# keyed by the *given* session id, the new-pane path, the respawn-existing-pane
+# path (simulating a tmux-resurrect restore), and session-id validation.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
+WDIR=/tmp/claude-workers
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { echo "  PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "  FAIL: $1 - ${2:-}"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+TMUX_NEW="test-csd-adopt-new-$$"
+TMUX_RESPAWN="test-csd-adopt-respawn-$$"
+SID_NEW=$(uuidgen | tr '[:upper:]' '[:lower:]')
+SID_RESPAWN=$(uuidgen | tr '[:upper:]' '[:lower:]')
+FAKE_HOME=$(mktemp -d)
+FAKE_CLAUDE=$(mktemp)
+
+cleanup() {
+  tmux kill-session -t "$TMUX_NEW" 2>/dev/null || true
+  tmux kill-session -t "$TMUX_RESPAWN" 2>/dev/null || true
+  rm -rf "$FAKE_HOME"
+  rm -f "$FAKE_CLAUDE"
+  rm -f "$WDIR/$SID_NEW".* "$WDIR/$SID_RESPAWN".*
+  rm -f "$WDIR/bin/$TMUX_NEW" "$WDIR/bin/$TMUX_RESPAWN"
+}
+trap cleanup EXIT
+cleanup
+mkdir -p "$WDIR" "$WDIR/bin" "$FAKE_HOME/.claude"
+touch "$FAKE_HOME/.claude/.claude-session-driver-consent"
+
+# Stub claude that writes a session_start event keyed off --resume (adopt uses
+# --resume, not --session-id). Mirrors the fake-claude trick in test-csd-launch.
+cat > "$FAKE_CLAUDE" <<'BASH'
+#!/bin/bash
+SID=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --resume) SID="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p /tmp/claude-workers
+echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"event\":\"session_start\",\"cwd\":\"$PWD\"}" \
+  > "/tmp/claude-workers/${SID}.events.jsonl"
+exec sleep 60
+BASH
+chmod +x "$FAKE_CLAUDE"
+
+# ---- 1. New-pane path (no pre-existing tmux session) ----------------------
+OUT=$(CSD_CLAUDE_BIN="$FAKE_CLAUDE" HOME="$FAKE_HOME" \
+      bash "$CSD" adopt "$TMUX_NEW" /tmp "$SID_NEW" -- --model sonnet 2>/tmp/adopt-err-$$)
+ERR=$(cat /tmp/adopt-err-$$ || true); rm -f /tmp/adopt-err-$$
+SHIM="$WDIR/bin/$TMUX_NEW"
+
+[ "$OUT" = "$SHIM" ] && pass "stdout is the shim path" || fail "stdout" "expected '$SHIM', got '$OUT'"
+[ -x "$SHIM" ] && pass "shim is executable" || fail "shim exec" "$SHIM"
+grep -q "exec.*csd.*--worker \"$TMUX_NEW\"" "$SHIM" && pass "shim execs csd with --worker" || fail "shim body" "$(cat "$SHIM")"
+
+# meta is keyed by the GIVEN session id (the whole point: resume preserves it)
+if [ -f "$WDIR/$SID_NEW.meta" ]; then
+  pass "meta is keyed by the given session id"
+else
+  fail "meta key" "$WDIR/$SID_NEW.meta missing"
+fi
+META_SID=$(jq -r '.session_id' "$WDIR/$SID_NEW.meta" 2>/dev/null || echo "")
+[ "$META_SID" = "$SID_NEW" ] && pass "meta.session_id == given id" || fail "meta sid" "$META_SID vs $SID_NEW"
+
+# worker is live: session_start recorded
+grep -q '"event":"session_start"' "$WDIR/$SID_NEW.events.jsonl" 2>/dev/null \
+  && pass "session_start recorded (worker live)" || fail "session_start" "no event"
+
+# reproduce + panel say adopt, not launch
+echo "$ERR" | grep -q "Worker adopted (opened new pane)" && pass "panel: opened new pane" || fail "panel mode" "$ERR"
+echo "$ERR" | grep -q "reproduce:.*adopt $TMUX_NEW /tmp $SID_NEW -- --model sonnet" \
+  && pass "reproduce line says adopt" || fail "reproduce" "$ERR"
+
+# shim routes to the right worker
+SID_VIA_SHIM=$("$SHIM" session-id 2>/dev/null || echo "")
+[ "$SID_VIA_SHIM" = "$SID_NEW" ] && pass "shim routes to the right worker" || fail "shim routing" "$SID_VIA_SHIM vs $SID_NEW"
+
+# ---- 2. Respawn-existing-pane path (simulate a tmux-resurrect restore) -----
+# Pre-create a session with a dead-ish command, as continuum would on restore.
+tmux new-session -d -s "$TMUX_RESPAWN" "sleep 300"
+OUT2=$(CSD_CLAUDE_BIN="$FAKE_CLAUDE" HOME="$FAKE_HOME" \
+       bash "$CSD" adopt "$TMUX_RESPAWN" /tmp "$SID_RESPAWN" 2>/tmp/adopt-err2-$$)
+ERR2=$(cat /tmp/adopt-err2-$$ || true); rm -f /tmp/adopt-err2-$$
+
+echo "$ERR2" | grep -q "Worker adopted (respawned existing pane)" \
+  && pass "respawns the pre-existing (restored) pane in place" || fail "respawn mode" "$ERR2"
+grep -q '"event":"session_start"' "$WDIR/$SID_RESPAWN.events.jsonl" 2>/dev/null \
+  && pass "respawned worker is live" || fail "respawn live" "no event"
+# the session name (and thus restored layout) is preserved, not recreated
+tmux has-session -t "$TMUX_RESPAWN" 2>/dev/null \
+  && pass "original session name preserved" || fail "session gone" "$TMUX_RESPAWN"
+
+# ---- 3. Validation: a non-uuid session id (e.g. a path) is rejected --------
+EC=0
+CSD_CLAUDE_BIN="$FAKE_CLAUDE" HOME="$FAKE_HOME" \
+  bash "$CSD" adopt bogus-name /tmp "/tmp/not/a/session" 2>/dev/null >/dev/null || EC=$?
+[ "$EC" -ne 0 ] && pass "rejects a non-uuid session id" || fail "validation" "exit 0"
+
+# ---- 4. Consent is required ------------------------------------------------
+EC=0
+NOCONSENT=$(mktemp -d)
+CSD_CLAUDE_BIN="$FAKE_CLAUDE" HOME="$NOCONSENT" \
+  bash "$CSD" adopt bogus2 /tmp "$(uuidgen)" 2>/dev/null >/dev/null || EC=$?
+rm -rf "$NOCONSENT"
+[ "$EC" -ne 0 ] && pass "requires consent" || fail "consent" "exit 0"
+
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+echo ""
+echo "Results: $PASS_COUNT/$TOTAL passed, $FAIL_COUNT failed"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## What

Adds **`csd adopt <tmux-name> <cwd> <session-id> [-- claude-args...]`** — re-adopt an existing Claude session as a live, driveable worker via `claude --resume`.

## Why

Worker runtime state (the `meta`/`events`/`shim` files under `/tmp/claude-workers`) lives in `/tmp`, which **macOS clears on reboot** — and the tmux panes die with it. Today the only recovery is `csd launch`, which starts a *fresh* conversation. But the conversations aren't actually lost: Claude Code persists every session transcript under `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`. `adopt` brings one of those back as a fully driveable worker, with all prior context intact.

This pairs naturally with [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect)/`tmux-continuum`: continuum's `@continuum-boot` restores your tmux layout after a reboot, and `adopt` re-animates each restored pane as a real csd worker.

## How it works

The key fact (verified empirically): **`claude --resume <id>` preserves the session id** — no fork, same transcript. So `adopt`:

1. Pre-writes the `meta` keyed by `<session-id>` **before** starting claude. This matters: `hooks/emit-event` only records events once `/tmp/claude-workers/<session_id>.meta` exists, and on resume the runtime session id equals the id we were handed — so the worker emits `session_start`/`stop`/… normally.
2. Starts `claude --resume <session-id>` (instead of `--session-id`), mirroring `launch`'s flags/env.
3. Writes the same 3-line shim, so the resumed conversation is driveable through the existing `converse`/`status`/`read-turn`/… surface.

If a tmux session of that name already exists (e.g. restored by tmux-resurrect), `adopt` **respawns its pane in place** (`respawn-pane -k`) to preserve the restored layout; otherwise it opens a new one.

## Changes

- **`cmd_adopt`** in `csd`, registered in dispatch + usage.
- Extracted **`_await_session_start`** and **`_write_worker_shim`** helpers shared by `cmd_launch` and `cmd_adopt` — `launch` behavior is unchanged (the existing 9 launch tests act as the regression guard).
- **`tests/test-csd-adopt.sh`** — 14 assertions: stdout/shim contract, meta keyed by the *given* id, the new-pane path, the respawn-existing-pane path (simulating a tmux-resurrect restore), session-id validation, consent.
- **`examples/recover-workers.sh`** — reference bulk-recovery tool built on `adopt`: derives each worker's session id from a tmux-resurrect snapshot (or live tmux) + the `~/.claude/projects` transcripts. Has `--dry-run`, `--manifest` pins (for a cwd shared by >1 session, e.g. the repo root used by both a worker and the driver), and `--pattern`. bash 3.2-safe.
- Docs: SKILL.md "Recovering workers after a reboot" + CHANGELOG.

## Testing

All 17 suites pass (174 assertions incl. the new 14). Also validated end-to-end with a real worker: launch → seed a codeword → stop (drop all csd state, simulating a reboot) → `csd adopt` → drive the adopted worker → it recalled the pre-reboot codeword. Verified `respawn-pane -e` on tmux 3.6a and the example under `/bin/bash` 3.2.

Co-authored-by: Claude <noreply@anthropic.com>