### PR TITLE
feat: drive Codex and Pi workers alongside Claude

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-session-driver",
-  "description": "Launch, control, and monitor other Claude Code sessions as workers via tmux",
+  "description": "Launch, control, and monitor coding-agent sessions (Claude Code, Codex, Pi) as workers via tmux",
   "version": "3.0.2",
   "author": {
     "name": "Jesse Vincent",

--- a/README.md
+++ b/README.md
@@ -1,16 +1,30 @@
 # claude-session-driver
 
-Turn one Claude Code session into a project manager that delegates tasks to other Claude Code sessions.
+Turn one coding-agent session into a project manager that delegates tasks to other sessions — Claude Code, Codex, or Pi.
 
 ## Why
 
-A single Claude session works on one task at a time. With this plugin, a controller session launches worker sessions in tmux, assigns each a task, monitors their progress, and collects results. Workers run in parallel. The controller decides what to do with their output.
+A single coding-agent session works on one task at a time. With this plugin, a controller session launches worker sessions in tmux, assigns each a task, monitors their progress, and collects results. Workers run in parallel. The controller decides what to do with their output.
 
 ## How It Works
 
-Workers run with `--dangerously-skip-permissions` and execute tool calls without prompting. The plugin's hooks write lifecycle events to a JSONL file — session start, prompt submitted, each tool call (with name and input), stop, and session end — so a controller can watch what each worker is doing. The events are observation-only; the plugin does not gate tool calls.
+Workers run with permissions bypassed and execute tool calls without prompting. Each worker emits lifecycle events to a JSONL file — session start, prompt submitted, each tool call (with name and input), stop, and session end — so a controller can watch what each worker is doing. The events are observation-only; nothing gates the tool calls.
+
+Claude and Codex emit those events through their own hook systems. Pi has none, so `csd` tails its transcript and synthesizes the same stream. The controller drives every worker the same way and never learns which harness is inside the pane.
 
 The controller orchestrates workers through a single CLI (`csd`) that manages tmux sessions, polls events, reads conversation logs, and cleans up.
+
+## Harnesses
+
+`csd` drives three harnesses. Pass `--harness` at launch; it defaults to `claude`.
+
+| `--harness` | CLI | Auth |
+|------------|------|------|
+| `claude` (default) | `claude` | your `~/.claude` login |
+| `codex` | `codex` | your `~/.codex` login |
+| `pi` | `pi` | your `~/.pi/agent` login |
+
+The controller surface is identical for all three — `converse`, `read-turn`, `stop`, and the rest behave the same regardless of what's in the pane. One difference leaks through: Claude takes a caller-assigned session id, while Codex and Pi mint their own on the first prompt. So `adopt` (resume a session by id) is Claude-only; relaunch a Codex or Pi worker instead.
 
 ## Installation
 
@@ -24,7 +38,7 @@ If your marketplace cache predates this plugin, update it first:
 claude plugin marketplace update superpowers-marketplace
 ```
 
-Requires **tmux**, **jq**, and the **claude** CLI.
+Requires **tmux** and **jq**, plus at least one harness CLI — **claude**, **codex**, or **pi**.
 
 ## Usage
 
@@ -46,7 +60,7 @@ All operations go through a single binary at `skills/driving-claude-code-session
 
 | Subcommand | Purpose |
 |------------|---------|
-| `csd launch <name> <cwd> [-- claude-args...]` | Bootstrap a worker; prints a shim path to stdout |
+| `csd launch [--harness <h>] <name> <cwd> [-- harness-args...]` | Bootstrap a worker (harness defaults to `claude`); prints a shim path to stdout |
 | `csd list [--all]` | List active (or all) workers |
 | `csd grant-consent` | One-time consent flow (required before first launch) |
 

--- a/docs/superpowers/plans/2026-06-05-csd-multiharness-phase1-driver-refactor.md
+++ b/docs/superpowers/plans/2026-06-05-csd-multiharness-phase1-driver-refactor.md
@@ -4,31 +4,40 @@
 
 **Goal:** Move Claude's harness-specific knowledge in `csd` behind a per-harness driver abstraction, with **zero Claude behavior change**, so Codex and Pi drivers can plug in later (Phases 2–3).
 
-**Architecture:** A sourced driver file `scripts/drivers/claude.sh` implements a fixed set of *slot functions* (the seven ports from the spec). The `csd` spine calls slots and never names a harness; it loads the driver from the worker's `.meta` (`harness` field, default `claude`) or, for `launch`/`adopt`, from a new `--harness` flag (default `claude`). The existing 18-script test suite is the characterization harness: every extraction keeps it green.
+**Architecture:** A sourced driver file `scripts/drivers/claude.sh` implements a fixed set of *slot functions* (the seven ports from the spec). The `csd` spine calls slots and never names a harness; the dispatch layer loads the driver from the worker's `.meta` (`harness` field, default `claude`) or, for `launch`/`adopt`, defaults to `claude` (a `--harness` flag is added in Task 8). The existing 18-script bash test suite is the characterization harness: every extraction keeps it green.
 
-**Tech Stack:** Bash, `jq`, `tmux`. Tests are standalone bash scripts run as `bash tests/test-csd-<name>.sh`; `claude` is mocked via `CSD_CLAUDE_BIN`.
+**Tech Stack:** Bash **3.2** (`/bin/bash` on macOS — NO `mapfile`, NO associative arrays), `jq`, `tmux`. Tests are standalone bash scripts run as `bash tests/test-csd-<name>.sh`; `claude` is mocked via `CSD_CLAUDE_BIN`.
 
 **Spec:** `docs/superpowers/specs/2026-06-05-csd-multiharness-design.md`
 
 **Out of scope (later plans):** Codex driver (Phase 2), Pi driver + `csd poll` tailer (Phase 3).
 
+**Reviewer-found constraints baked into this revision (Riker@c9ac5ed5):**
+- `/bin/bash` is 3.2.57 — `mapfile` is absent; use a `while read` loop to collect argv.
+- `full` is the *string* `true`/`false`; `${full:+--full}` is wrong (always non-empty). Guard with `[ "$full" = true ]`.
+- The driver must be loaded **before** any per-worker command calls a slot → central load is Task 1.
+- `hooks/emit-event` hardcodes `/tmp/claude-workers` (4 sites) and must be migrated in the rename task.
+- `/tmp/claude-workers` already exists as a real dir → the back-compat symlink must handle that.
+- `csd` has 31 literal `/tmp/claude-workers` sites and uses `$_CSD_WORKER_DIR` nowhere → parameterize early (Task 2), flip the default late (Task 9).
+
 ---
 
 ## File Structure
 
-- **Create** `skills/driving-claude-code-sessions/scripts/drivers/claude.sh` — Claude driver; implements all slot functions. One responsibility: encode everything Claude-specific.
-- **Modify** `skills/driving-claude-code-sessions/scripts/_lib.sh` — add `_CSD_SCRIPT_DIR`, `_load_driver`; parameterize `_CSD_WORKER_DIR`.
-- **Modify** `skills/driving-claude-code-sessions/scripts/csd` — route `cmd_launch`/`cmd_adopt`/`cmd_stop`/`cmd_read_turn`/`cmd_converse` through slots; add `--harness` flag; persist `harness` in meta; load the driver in dispatch.
-- **Create** `tests/test-csd-drivers.sh` — unit tests for the driver loader and Claude slot outputs.
+- **Create** `skills/driving-claude-code-sessions/scripts/drivers/claude.sh` — Claude driver; all slot functions.
+- **Modify** `skills/driving-claude-code-sessions/scripts/_lib.sh` — add `_CSD_SCRIPT_DIR`, `_load_driver`; (Task 9) flip `_CSD_WORKER_DIR` default.
+- **Modify** `skills/driving-claude-code-sessions/scripts/csd` — central driver load in dispatch; route launch/adopt/stop/read-turn/converse through slots; parameterize worker-dir; add `--harness`.
+- **Modify** `hooks/emit-event` — (Task 9) parameterize worker-dir.
+- **Create** `tests/test-csd-drivers.sh` — unit tests for the loader and Claude slot outputs.
 
 ### The slot contract (final shape after Phase 1)
 
 ```
-harness_id                                    # echoes the harness id, e.g. "claude"
-harness_bin                                   # echoes the resolved binary (honors CSD_<H>_BIN)
+harness_id                                    # echoes "claude"
+harness_bin                                   # echoes ${CSD_CLAUDE_BIN:-claude}
 harness_control_plane                         # "hooks" | "poll"
 harness_id_strategy                           # "assign" | "derive"
-harness_quit_keys                             # literal keys to quit the TUI, e.g. "/exit"
+harness_quit_keys                             # literal TUI quit keys, e.g. "/exit"
 harness_env_args                              # populates array WORKER_ENV_ARGS=(-e VAR=… …)
 harness_launch_argv <mode> <sid> <plugin_dir> # mode=launch|resume; prints argv tokens, one per line
 harness_transcript_path <sid> <cwd>           # echoes the transcript file path
@@ -39,11 +48,13 @@ harness_last_text  <transcript>               # echoes the last assistant text b
 
 ---
 
-## Task 1: Driver loader + Claude manifest slots
+## Task 1: Driver loader, manifest slots, and central dispatch load
+
+Establishes the loader and loads the driver in dispatch **before** any command runs, so later tasks can route per-worker commands through slots safely.
 
 **Files:**
-- Create: `skills/driving-claude-code-sessions/scripts/drivers/claude.sh`
-- Modify: `skills/driving-claude-code-sessions/scripts/_lib.sh`
+- Create: `scripts/drivers/claude.sh`
+- Modify: `scripts/_lib.sh`, `scripts/csd`
 - Test: `tests/test-csd-drivers.sh`
 
 - [ ] **Step 1: Write the failing test** — `tests/test-csd-drivers.sh`
@@ -56,8 +67,6 @@ SCR="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts"
 PASS=0; FAIL=0
 pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
 fail() { echo "  FAIL: $1 - $2"; FAIL=$((FAIL+1)); }
-
-# Load the lib + claude driver in a subshell and probe slot outputs.
 probe() { ( source "$SCR/_lib.sh"; _load_driver claude; "$@" ); }
 
 [ "$(probe harness_id)" = "claude" ] && pass "harness_id=claude" || fail "harness_id" "got $(probe harness_id)"
@@ -66,9 +75,7 @@ probe() { ( source "$SCR/_lib.sh"; _load_driver claude; "$@" ); }
 [ "$(probe harness_quit_keys)" = "/exit" ] && pass "quit_keys=/exit" || fail "quit_keys" "wrong"
 [ "$(probe harness_bin)" = "claude" ] && pass "bin defaults to claude" || fail "bin" "wrong"
 [ "$(CSD_CLAUDE_BIN=/x/claude probe harness_bin)" = "/x/claude" ] && pass "bin honors CSD_CLAUDE_BIN" || fail "bin override" "wrong"
-
-# Unknown harness fails loudly.
-if ( source "$SCR/_lib.sh"; _load_driver nope ) 2>/dev/null; then fail "unknown driver" "should have failed"; else pass "unknown driver errors"; fi
+if ( source "$SCR/_lib.sh"; _load_driver nope ) 2>/dev/null; then fail "unknown driver" "should fail"; else pass "unknown driver errors"; fi
 
 echo "drivers: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]
 ```
@@ -76,17 +83,17 @@ echo "drivers: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]
 - [ ] **Step 2: Run it to verify it fails**
 
 Run: `bash tests/test-csd-drivers.sh`
-Expected: FAIL — `_load_driver: command not found` (lib doesn't define it yet).
+Expected: FAIL — `_load_driver: command not found`.
 
 - [ ] **Step 3: Add loader + script-dir to `_lib.sh`**
 
-At the top of `_lib.sh`, after the header comment and before `_CSD_WORKER_DIR=`, add:
+After the header comment, before `_CSD_WORKER_DIR=`, add:
 
 ```bash
-# Absolute path to scripts/ (this file's directory). Used to locate drivers/.
+# Absolute path to scripts/ (this file's dir). Used to locate drivers/.
 _CSD_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Source the harness driver for <harness> (default claude). Driver files live at
+# Source the harness driver for <harness> (default claude). Drivers live at
 # scripts/drivers/<harness>.sh and define the harness slot functions.
 _load_driver() {
   local harness="${1:-claude}"
@@ -105,7 +112,7 @@ _load_driver() {
 ```bash
 #!/bin/bash
 # Claude Code harness driver for csd. Sourced, not executed. Implements the
-# harness slot contract (see docs/superpowers/specs/2026-06-05-csd-multiharness-design.md).
+# harness slot contract (docs/superpowers/specs/2026-06-05-csd-multiharness-design.md).
 
 harness_id()            { echo "claude"; }
 harness_bin()           { echo "${CSD_CLAUDE_BIN:-claude}"; }
@@ -114,43 +121,97 @@ harness_id_strategy()   { echo "assign"; }
 harness_quit_keys()     { echo "/exit"; }
 ```
 
-- [ ] **Step 5: Run the test to verify it passes**
+- [ ] **Step 5: Load the driver centrally in dispatch**
+
+In `csd`, after the SUB/WORKER validation block and the `shift` that consumes the subcommand (just before `case "$SUB" in`), insert:
+
+```bash
+# Load the harness driver before dispatching. Per-worker subs read the harness
+# from the worker meta (default claude); launch/adopt default to claude here
+# (Task 8 adds the --harness flag + per-command override).
+if is_in "$SUB" "${PER_WORKER_SUBS[@]}"; then
+  _wsid=$(resolve_session "$WORKER") || exit 1
+  _whar=$(jq -r '.harness // "claude"' "/tmp/claude-workers/${_wsid}.meta" 2>/dev/null)
+  _load_driver "${_whar:-claude}"
+elif [ "$SUB" = "launch" ] || [ "$SUB" = "adopt" ]; then
+  _load_driver claude
+fi
+```
+
+(Uses literal `/tmp/claude-workers` for now; Task 2 parameterizes it.)
+
+- [ ] **Step 6: Run the driver test + full suite**
 
 Run: `bash tests/test-csd-drivers.sh`
-Expected: PASS — all 7 assertions, `drivers: 7 passed, 0 failed`.
-
-- [ ] **Step 6: Verify existing suite still green** (csd doesn't call the loader yet, so nothing should change)
-
-Run: `bash tests/test-csd-skeleton.sh && bash tests/test-csd-launch.sh`
-Expected: PASS for both.
+Expected: PASS — `drivers: 7 passed, 0 failed`.
+Run: `for t in tests/test-csd-*.sh; do bash "$t" >/dev/null && echo "ok $t" || echo "FAIL $t"; done`
+Expected: every script `ok` (driver load is a no-op for behavior; slots aren't called yet).
 
 - [ ] **Step 7: Commit**
 
 ```bash
 git add skills/driving-claude-code-sessions/scripts/drivers/claude.sh \
-        skills/driving-claude-code-sessions/scripts/_lib.sh tests/test-csd-drivers.sh
-git commit -m "refactor(csd): add driver loader + claude manifest slots (PRI-2096)"
+        skills/driving-claude-code-sessions/scripts/_lib.sh \
+        skills/driving-claude-code-sessions/scripts/csd tests/test-csd-drivers.sh
+git commit -m "refactor(csd): driver loader, claude manifest slots, central load (PRI-2096)"
 ```
 
 ---
 
-## Task 2: Extract `harness_env_args`
+## Task 2: Parameterize the worker dir to `$_CSD_WORKER_DIR` (zero behavior change)
 
-Moves the provider-env pinning (`_PROVIDER_ENV_VARS` + `_build_worker_env_args`, csd lines ~665–691) into the driver. The spine calls `harness_env_args` instead.
+`_lib.sh` already defines `_CSD_WORKER_DIR=/tmp/claude-workers`, but `csd` never uses it (31 literal sites). Convert them now while the value is unchanged, so Task 9 only flips the default.
 
 **Files:**
-- Modify: `drivers/claude.sh`
-- Modify: `scripts/csd` (remove `_PROVIDER_ENV_VARS`/`_build_worker_env_args`; call `harness_env_args`)
-- Test: `tests/test-csd-drivers.sh`, `tests/test-csd-provider-env.sh`
+- Modify: `scripts/csd`
+- Test: full suite
 
-- [ ] **Step 1: Add the failing slot assertions** — append to `tests/test-csd-drivers.sh` before the final echo:
+- [ ] **Step 1: Replace runtime literals with the variable**
+
+In `csd`, replace every `/tmp/claude-workers` with `$_CSD_WORKER_DIR`. This includes the `usage()` heredoc (it is an **unquoted** `cat <<EOF`, so the variable expands and help text stays accurate) and the doubled occurrences in `mkdir -p /tmp/claude-workers /tmp/claude-workers/bin` (both → `$_CSD_WORKER_DIR`). Also update the dispatch block from Task 1.
+
+Apply, then verify none remain:
+```bash
+sed -i '' 's#/tmp/claude-workers#$_CSD_WORKER_DIR#g' skills/driving-claude-code-sessions/scripts/csd
+grep -n '/tmp/claude-workers' skills/driving-claude-code-sessions/scripts/csd
+```
+Expected: no matches.
+
+- [ ] **Step 2: Sanity-check the shim heredoc didn't get clobbered**
+
+`_write_worker_shim` writes a shim via `cat > "$shim_path" <<EOF` containing `exec "$CSD_PATH" --worker …` — it has no worker-dir path, so it's untouched. Confirm the shim still execs csd:
+```bash
+grep -n 'exec "\$CSD_PATH"' skills/driving-claude-code-sessions/scripts/csd
+```
+Expected: the exec line is intact.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `for t in tests/test-*.sh; do bash "$t" >/dev/null && echo "ok $t" || echo "FAIL $t"; done`
+Expected: every script `ok` (`_CSD_WORKER_DIR` is still `/tmp/claude-workers`).
+
+- [ ] **Step 4: Commit**
 
 ```bash
-# harness_env_args populates WORKER_ENV_ARGS; SSE_PORT always pinned empty,
-# an UNSET provider var is pinned empty, a SET one is left to inherit.
+git add -A && git commit -m "refactor(csd): use \$_CSD_WORKER_DIR instead of literal path (PRI-2096)"
+```
+
+---
+
+## Task 3: Extract `harness_env_args`
+
+Moves provider-env pinning (`_PROVIDER_ENV_VARS` at csd:665, `_build_worker_env_args` at csd:678) into the driver.
+
+**Files:**
+- Modify: `drivers/claude.sh`, `scripts/csd`
+- Test: `tests/test-csd-drivers.sh`, `tests/test-csd-provider-env.sh`, `tests/test-csd-launch.sh`
+
+- [ ] **Step 1: Add failing slot assertions** — append to `tests/test-csd-drivers.sh` before the final echo:
+
+```bash
 envprobe() { ( source "$SCR/_lib.sh"; _load_driver claude; "$@"; harness_env_args; printf '%s\n' "${WORKER_ENV_ARGS[@]}" ); }
 out=$(unset CLAUDE_CODE_USE_BEDROCK; envprobe true)
-echo "$out" | grep -qx -- "-e" && echo "$out" | grep -qx "CLAUDE_CODE_SSE_PORT=" && pass "env: SSE_PORT pinned" || fail "env SSE_PORT" "missing"
+echo "$out" | grep -qx "CLAUDE_CODE_SSE_PORT=" && pass "env: SSE_PORT pinned" || fail "env SSE_PORT" "missing"
 echo "$out" | grep -qx "CLAUDE_CODE_USE_BEDROCK=" && pass "env: unset bedrock pinned empty" || fail "env bedrock unset" "missing"
 out2=$(CLAUDE_CODE_USE_BEDROCK=1 envprobe true)
 echo "$out2" | grep -qx "CLAUDE_CODE_USE_BEDROCK=" && fail "env set-bedrock" "should NOT pin a set var" || pass "env: set bedrock left to inherit"
@@ -165,8 +226,8 @@ Expected: FAIL — `harness_env_args: command not found`.
 
 ```bash
 # Provider/auth vars Claude resolves from the process env (issue #18). Pinned
-# empty when unset in this process (kills stale tmux-global values); left to
-# inherit when set here (so credentials travel with the selector).
+# empty when unset here (kills stale tmux-global values); left to inherit when
+# set here (so credentials travel with the selector).
 _CLAUDE_PROVIDER_ENV_VARS=(
   CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
   CLAUDE_CODE_USE_BEDROCK
@@ -191,24 +252,12 @@ harness_env_args() {
 
 - [ ] **Step 4: Remove the originals from `csd` and call the slot**
 
-In `csd`, delete the `_PROVIDER_ENV_VARS=(...)` array (and its long comment block, ~lines 617–672) and the `_build_worker_env_args() { ... }` function (~lines 674–691). In `cmd_launch` and `cmd_adopt`, replace the two lines:
-
-```bash
-  local WORKER_ENV_ARGS=()
-  _build_worker_env_args
-```
-with:
-```bash
-  local WORKER_ENV_ARGS=()
-  harness_env_args
-```
-
-(The driver is loaded in dispatch — Task 7 — but for now add a temporary `_load_driver claude` at the top of `cmd_launch`/`cmd_adopt` just before `harness_env_args`; Task 7 removes these temporary loads when dispatch loads the driver centrally.)
+Delete the `_PROVIDER_ENV_VARS=(...)` array + its comment block (csd ~617–672) and the `_build_worker_env_args() { ... }` function (csd ~674–691). In `cmd_launch` and `cmd_adopt`, both already call `_build_worker_env_args` after `local WORKER_ENV_ARGS=()`; replace each `_build_worker_env_args` call with `harness_env_args`. (The driver is already loaded centrally — Task 1 — for launch/adopt, so no per-function load is needed.)
 
 - [ ] **Step 5: Run tests to verify green**
 
-Run: `bash tests/test-csd-drivers.sh && bash tests/test-csd-provider-env.sh && bash tests/test-csd-launch.sh`
-Expected: PASS for all three.
+Run: `bash tests/test-csd-drivers.sh && bash tests/test-csd-provider-env.sh && bash tests/test-csd-launch.sh && bash tests/test-csd-adopt.sh`
+Expected: PASS for all four.
 
 - [ ] **Step 6: Commit**
 
@@ -218,9 +267,9 @@ git add -A && git commit -m "refactor(csd): move provider-env pinning into harne
 
 ---
 
-## Task 3: Extract `harness_launch_argv` (launch + resume)
+## Task 4: Extract `harness_launch_argv` (launch + resume), bash-3.2 safe
 
-Moves the `claude --session-id … --plugin-dir … --dangerously-skip-permissions --disallowed-tools AskUserQuestion` construction (csd ~757–763) and the `--resume` variant (cmd_adopt ~861–876) into one slot taking a `mode` of `launch` or `resume`.
+Moves the `claude --session-id …` construction (csd:757) and the `--resume` variant (cmd_adopt:861–876) into one slot. **No `mapfile`** — collect with a read loop.
 
 **Files:**
 - Modify: `drivers/claude.sh`, `scripts/csd`
@@ -230,10 +279,12 @@ Moves the `claude --session-id … --plugin-dir … --dangerously-skip-permissio
 
 ```bash
 argv_launch=$( ( source "$SCR/_lib.sh"; _load_driver claude; harness_launch_argv launch SID123 /plug ) )
-echo "$argv_launch" | head -1 | grep -qx "claude" && pass "launch argv starts with bin" || fail "launch argv bin" "wrong"
+[ "$(echo "$argv_launch" | head -1)" = "claude" ] && pass "launch argv starts with bin" || fail "launch argv bin" "wrong"
 echo "$argv_launch" | grep -qx -- "--session-id" && echo "$argv_launch" | grep -qx "SID123" && pass "launch uses --session-id" || fail "launch sid" "wrong"
 echo "$argv_launch" | grep -qx -- "--dangerously-skip-permissions" && pass "launch bypass flag" || fail "bypass" "wrong"
 echo "$argv_launch" | grep -qx "AskUserQuestion" && pass "launch disallows AskUserQuestion" || fail "disallow" "wrong"
+# The --settings JSON survives as ONE token.
+echo "$argv_launch" | grep -qFx '{"skipDangerousModePermissionPrompt":true}' && pass "settings is one token" || fail "settings token" "split"
 argv_resume=$( ( source "$SCR/_lib.sh"; _load_driver claude; harness_launch_argv resume SID123 /plug ) )
 echo "$argv_resume" | grep -qx -- "--resume" && pass "resume uses --resume" || fail "resume" "wrong"
 echo "$argv_resume" | grep -qx -- "--session-id" && fail "resume sid" "should not use --session-id" || pass "resume omits --session-id"
@@ -252,8 +303,9 @@ Expected: FAIL — `harness_launch_argv: command not found`.
 # The spine wraps this with tmux + env args + any user extra-args.
 harness_launch_argv() {
   local mode="$1" sid="$2" plugin_dir="$3"
-  local bin; bin=$(harness_bin)
-  local idflag="--session-id"
+  local bin idflag
+  bin=$(harness_bin)
+  idflag="--session-id"
   [ "$mode" = "resume" ] && idflag="--resume"
   printf '%s\n' \
     "$bin" "$idflag" "$sid" --plugin-dir "$plugin_dir" \
@@ -263,13 +315,14 @@ harness_launch_argv() {
 }
 ```
 
-- [ ] **Step 4: Route `cmd_launch` through the slot**
+- [ ] **Step 4: Route `cmd_launch` through the slot (read loop, not mapfile)**
 
-In `cmd_launch`, replace the `tmux new-session` block (the `local claude_bin=…` line through the closing `"${extra_args[@]+...}"`, ~754–763) with:
+In `cmd_launch`, replace the `local claude_bin=…` line and the `tmux new-session … "${extra_args[@]+...}"` block (csd ~754–763) with:
 
 ```bash
   local launch_argv=()
-  mapfile -t launch_argv < <(harness_launch_argv launch "$session_id" "$plugin_dir")
+  while IFS= read -r _tok; do launch_argv+=("$_tok"); done \
+    < <(harness_launch_argv launch "$session_id" "$plugin_dir")
   local WORKER_ENV_ARGS=()
   harness_env_args
   tmux new-session -d -s "$tmux_name" -c "$working_dir" \
@@ -278,25 +331,24 @@ In `cmd_launch`, replace the `tmux new-session` block (the `local claude_bin=…
     "${extra_args[@]+"${extra_args[@]}"}"
 ```
 
-(Removes the now-unused `local claude_bin=…`.)
-
 - [ ] **Step 5: Route `cmd_adopt` through the slot**
 
-In `cmd_adopt`, both branches (`respawn-pane` and `new-session`) construct the claude argv inline. Replace the `local claude_bin=…` + `_build_worker_env_args` lines and both inline argv lists so each tmux call uses:
+In `cmd_adopt`, replace the `local claude_bin=…` + `_build_worker_env_args` lines (already `harness_env_args` after Task 3) and BOTH inline argv lists. Before the `if tmux has-session` branch, build once:
 
 ```bash
   local launch_argv=()
-  mapfile -t launch_argv < <(harness_launch_argv resume "$session_id" "$plugin_dir")
+  while IFS= read -r _tok; do launch_argv+=("$_tok"); done \
+    < <(harness_launch_argv resume "$session_id" "$plugin_dir")
   local WORKER_ENV_ARGS=()
   harness_env_args
 ```
-then in the respawn branch:
+respawn branch:
 ```bash
     tmux respawn-pane -k -t "$tmux_name" -c "$working_dir" \
       "${WORKER_ENV_ARGS[@]}" "${launch_argv[@]}" \
       "${extra_args[@]+"${extra_args[@]}"}"
 ```
-and the new-session branch:
+new-session branch:
 ```bash
     tmux new-session -d -s "$tmux_name" -c "$working_dir" \
       "${WORKER_ENV_ARGS[@]}" "${launch_argv[@]}" \
@@ -316,9 +368,9 @@ git add -A && git commit -m "refactor(csd): route launch/adopt through harness_l
 
 ---
 
-## Task 4: Extract `harness_transcript_path`
+## Task 5: Extract `harness_transcript_path` (preserve the null-cwd guard)
 
-Moves the `$HOME/.claude/projects/${cwd//\//-}/${sid}.jsonl` derivation (duplicated in `cmd_read_turn` ~298–309 and `cmd_converse` ~368–379) into one slot.
+Moves the path formula (csd:300–309 in read-turn, 370–379 in converse) into the slot. The null-cwd guard stays in the callers (a behavior the original has and tests rely on for the error message).
 
 **Files:**
 - Modify: `drivers/claude.sh`, `scripts/csd`
@@ -336,11 +388,10 @@ tp=$( ( source "$SCR/_lib.sh"; _load_driver claude; HOME=/home/x harness_transcr
 Run: `bash tests/test-csd-drivers.sh`
 Expected: FAIL — `harness_transcript_path: command not found`.
 
-- [ ] **Step 3: Add the slot to `drivers/claude.sh`** (append):
+- [ ] **Step 3: Add the slot to `drivers/claude.sh`** (append). Keeps the `cd && pwd -P` resolution the spine did:
 
 ```bash
-# Echo the transcript path for <sid> in <cwd>. Resolves cwd to absolute first
-# (matches the spine's prior behavior).
+# Echo the transcript path for <sid> in <cwd> (cwd resolved to absolute first).
 harness_transcript_path() {
   local sid="$1" cwd="$2"
   if [ -d "$cwd" ]; then cwd=$(cd "$cwd" && pwd -P); fi
@@ -349,16 +400,16 @@ harness_transcript_path() {
 }
 ```
 
-- [ ] **Step 4: Route the spine through the slot**
+- [ ] **Step 4: Route the spine, keeping the null-cwd guard**
 
-In `cmd_read_turn`, replace the `cwd=…`/`encoded=…`/`log_file=…` derivation (the block computing `log_file`, ~300–309) with:
+In `cmd_read_turn`, the block (csd:300–309) reads `cwd` from meta, guards null, resolves `cwd`, builds `encoded`/`log_file`. Replace the `encoded=…`/`log_file=…` tail (keep the `cwd=$(jq …)` read and the `if [ -z "$cwd" ] || [ "$cwd" = "null" ]` guard) with:
 
 ```bash
-  local log_file
-  log_file=$(harness_transcript_path "$sid" "$(jq -r '.cwd' "/tmp/claude-workers/${sid}.meta")")
+  log_file=$(harness_transcript_path "$sid" "$cwd")
 ```
+(Delete the now-duplicate `if [ -d "$cwd" ]; then cwd=$(cd "$cwd" && pwd -P); fi` and `encoded=…` lines — the slot does both.)
 
-In `cmd_converse`, replace the analogous `cwd=…`/`encoded=…`/`log_file=…` block (~370–379) with the same two lines (keep the separate `event_file=…` line that follows).
+Apply the identical change in `cmd_converse` (csd:370–379), keeping its own null-cwd guard and the separate `event_file=…` line.
 
 - [ ] **Step 5: Run tests to verify green**
 
@@ -373,20 +424,20 @@ git add -A && git commit -m "refactor(csd): move transcript-path formula into sl
 
 ---
 
-## Task 5: Extract `harness_parse_turn`, `harness_count_text`, `harness_last_text`
+## Task 6: Extract `harness_parse_turn`, `harness_count_text`, `harness_last_text`
 
-Moves the big `jq` turn-renderer (`cmd_read_turn` ~316–356) and the two converse helpers (`count_text_messages`, `last_text_response`, ~382–392) into the driver.
+Moves the jq turn-renderer (csd:316–356) and the converse helpers (`count_text_messages` csd:382, `last_text_response` csd:389) into the driver. **Fixes the `${full:+--full}` bug** at the call site.
 
 **Files:**
 - Modify: `drivers/claude.sh`, `scripts/csd`
 - Test: `tests/test-csd-read-turn.sh`, `tests/test-csd-converse.sh`, `tests/test-csd-readers.sh`
 
-- [ ] **Step 1: Run the existing readers suite as the baseline (must already pass)**
+- [ ] **Step 1: Baseline (must already pass)**
 
 Run: `bash tests/test-csd-read-turn.sh && bash tests/test-csd-readers.sh && bash tests/test-csd-converse.sh`
-Expected: PASS — this is the characterization baseline this task must preserve.
+Expected: PASS — the characterization baseline this task preserves (including the truncate-to-5-lines assertion).
 
-- [ ] **Step 2: Add the three slots to `drivers/claude.sh`** (append). `harness_parse_turn` takes the transcript path and optional `--full`; it reproduces the current renderer verbatim (find last real user prompt line, then render assistant/user records):
+- [ ] **Step 2: Add the three slots to `drivers/claude.sh`** (append). `harness_parse_turn` preserves the original's "no user prompt" stderr message:
 
 ```bash
 # Render the last turn of <transcript> as markdown. With --full, tool results
@@ -398,7 +449,10 @@ harness_parse_turn() {
   last_prompt_line=$(grep -n '"type":"user"' "$log_file" \
     | grep -v '"tool_result"' | grep -v '<local-command' | grep -v '<command-name>' \
     | tail -1 | cut -d: -f1)
-  [ -z "$last_prompt_line" ] && return 1
+  if [ -z "$last_prompt_line" ]; then
+    echo "No user prompt found in session log" >&2
+    return 1
+  fi
   tail -n +"$last_prompt_line" "$log_file" \
     | jq -r --argjson full "$full" '
       select(.type == "assistant" or .type == "user") |
@@ -448,23 +502,24 @@ harness_last_text() {
 }
 ```
 
-- [ ] **Step 3: Route `cmd_read_turn` through the slot**
+- [ ] **Step 3: Route `cmd_read_turn` through the slot — correct `--full` handling**
 
-Replace the body of `cmd_read_turn` after `log_file` is resolved (the `if [ ! -f "$log_file" ]` check stays) — replace the `last_prompt_line=…` block plus the trailing `tail … | jq …` (~316–356) with:
+After `log_file` is resolved and the `if [ ! -f "$log_file" ]` check, replace the `last_prompt_line=…` block + trailing `tail … | jq …` (csd:316–356) with:
 
 ```bash
-  harness_parse_turn "$log_file" ${full:+--full}
+  local parse_full=()
+  [ "$full" = true ] && parse_full=(--full)
+  harness_parse_turn "$log_file" "${parse_full[@]+"${parse_full[@]}"}"
 ```
-(Keep `full` parsing at the top of `cmd_read_turn`.)
 
 - [ ] **Step 4: Route `cmd_converse` through the slots**
 
-In `cmd_converse`, delete the inline `count_text_messages()` and `last_text_response()` function definitions (~382–392). Replace their call sites: `before_count=$(count_text_messages)` → `before_count=$(harness_count_text "$log_file")`; `after_count=$(count_text_messages)` → `after_count=$(harness_count_text "$log_file")`; `response=$(last_text_response)` → `response=$(harness_last_text "$log_file")`.
+Delete the inline `count_text_messages()` and `last_text_response()` definitions (csd:382–392). Replace call sites: `before_count=$(count_text_messages)` → `before_count=$(harness_count_text "$log_file")`; `after_count=$(count_text_messages)` → `after_count=$(harness_count_text "$log_file")`; `response=$(last_text_response)` → `response=$(harness_last_text "$log_file")`.
 
-- [ ] **Step 5: Run tests to verify green**
+- [ ] **Step 5: Run tests to verify green (incl. truncation assertion)**
 
 Run: `bash tests/test-csd-read-turn.sh && bash tests/test-csd-readers.sh && bash tests/test-csd-converse.sh && bash tests/test-csd-converse-diag.sh`
-Expected: PASS for all four.
+Expected: PASS for all four — in particular the read-turn truncation/footer assertions (which would fail if `--full` were always passed).
 
 - [ ] **Step 6: Commit**
 
@@ -474,7 +529,7 @@ git add -A && git commit -m "refactor(csd): move turn parsing + converse text he
 
 ---
 
-## Task 6: Route `cmd_stop` through `harness_quit_keys`
+## Task 7: Route `cmd_stop` through `harness_quit_keys`
 
 **Files:**
 - Modify: `scripts/csd`
@@ -482,23 +537,14 @@ git add -A && git commit -m "refactor(csd): move turn parsing + converse text he
 
 - [ ] **Step 1: Baseline** — Run: `bash tests/test-csd-stop.sh` → Expected: PASS.
 
-- [ ] **Step 2: Replace the literal `/exit` in `cmd_stop`**
+- [ ] **Step 2: Replace the literal `/exit` in `cmd_stop` (csd:507)**
 
-In `cmd_stop`, replace:
-```bash
-    tmux send-keys -t "$tmux_name" -l '/exit'
-    tmux send-keys -t "$tmux_name" Enter
-```
-with:
 ```bash
     tmux send-keys -t "$tmux_name" -l "$(harness_quit_keys)"
     tmux send-keys -t "$tmux_name" Enter
 ```
 
-- [ ] **Step 3: Run test to verify green**
-
-Run: `bash tests/test-csd-stop.sh`
-Expected: PASS (Claude's `harness_quit_keys` is `/exit`, unchanged).
+- [ ] **Step 3: Run test** — Run: `bash tests/test-csd-stop.sh` → Expected: PASS (Claude's quit keys are `/exit`, unchanged).
 
 - [ ] **Step 4: Commit**
 
@@ -508,105 +554,99 @@ git add -A && git commit -m "refactor(csd): stop uses harness_quit_keys slot (PR
 
 ---
 
-## Task 7: `--harness` flag, persist in meta, load driver in dispatch
+## Task 8: `--harness` flag (after the subcommand), persist in meta
 
-Makes the harness a first-class, persisted axis (default `claude`), and centralizes driver loading so the temporary `_load_driver claude` calls from Task 2 are removed.
+Adds the harness selector matching the spec's syntax `csd launch --harness codex <name> <cwd>` (flag after the subcommand), persists it in meta, and re-loads the chosen driver.
 
 **Files:**
 - Modify: `scripts/csd`
-- Test: `tests/test-csd-launch.sh`, `tests/test-csd-drivers.sh`, full suite
+- Test: `tests/test-csd-drivers.sh`, full suite
 
 - [ ] **Step 1: Add a failing test** — append to `tests/test-csd-drivers.sh`:
 
 ```bash
-# After a launch, the meta records harness=claude (back-compat default).
-# (Reuses the fake-claude pattern; minimal inline check.)
 FAKE_HOME=$(mktemp -d); mkdir -p "$FAKE_HOME/.claude"; touch "$FAKE_HOME/.claude/.claude-session-driver-consent"
 FAKE_CLAUDE=$(mktemp); cat > "$FAKE_CLAUDE" <<'B'
 #!/bin/bash
 SID=""; while [ $# -gt 0 ]; do case "$1" in --session-id) SID="$2"; shift 2;; *) shift;; esac; done
-mkdir -p /tmp/claude-workers
-echo "{\"ts\":\"x\",\"event\":\"session_start\",\"cwd\":\"$PWD\"}" > "/tmp/claude-workers/${SID}.events.jsonl"; exec sleep 30
+mkdir -p /tmp/csd-workers
+echo "{\"ts\":\"x\",\"event\":\"session_start\",\"cwd\":\"$PWD\"}" > "/tmp/csd-workers/${SID}.events.jsonl"; exec sleep 30
 B
 chmod +x "$FAKE_CLAUDE"
 TN="test-drivers-meta-$$"
-SHIM=$(CSD_CLAUDE_BIN="$FAKE_CLAUDE" HOME="$FAKE_HOME" bash "$SCR/csd" launch "$TN" /tmp 2>/dev/null)
-SID=$(basename "$(grep -l "\"tmux_name\":\"$TN\"" /tmp/claude-workers/*.meta)" .meta)
-[ "$(jq -r '.harness' "/tmp/claude-workers/$SID.meta")" = "claude" ] && pass "meta records harness=claude" || fail "meta harness" "wrong"
-tmux kill-session -t "$TN" 2>/dev/null || true; rm -f "/tmp/claude-workers/$SID".* "/tmp/claude-workers/bin/$TN"; rm -rf "$FAKE_HOME" "$FAKE_CLAUDE"
+CSD_CLAUDE_BIN="$FAKE_CLAUDE" HOME="$FAKE_HOME" bash "$SCR/csd" launch "$TN" /tmp >/dev/null 2>&1
+META=$(grep -l "\"tmux_name\":\"$TN\"" /tmp/csd-workers/*.meta)
+[ "$(jq -r '.harness' "$META")" = "claude" ] && pass "meta records harness=claude" || fail "meta harness" "got $(jq -r '.harness' "$META")"
+SID=$(basename "$META" .meta)
+tmux kill-session -t "$TN" 2>/dev/null || true; rm -f "/tmp/csd-workers/$SID".* "/tmp/csd-workers/bin/$TN"; rm -rf "$FAKE_HOME" "$FAKE_CLAUDE"
 ```
+
+(Uses `/tmp/csd-workers` — the path after Task 9. If running Task 8 before Task 9, temporarily use `/tmp/claude-workers`; the suite is re-run after Task 9 regardless.)
 
 - [ ] **Step 2: Run to verify it fails**
 
 Run: `bash tests/test-csd-drivers.sh`
-Expected: FAIL — `.harness` is `null` (meta has no harness field yet).
+Expected: FAIL — `.harness` is `null`.
 
-- [ ] **Step 3: Parse `--harness` in `cmd_launch`/`cmd_adopt` and persist it**
+- [ ] **Step 3: Parse a leading `--harness` in `cmd_launch` and `cmd_adopt`**
 
-At the top of `cmd_launch` (and `cmd_adopt`), after the existing positional parsing, add harness parsing. Simplest: support `--harness <name>` immediately after the subcommand. In the main arg parser is cleaner — add a top-level `HARNESS` var alongside `WORKER`:
-
-In the main `while` loop that parses `--worker`, add cases:
-```bash
-    --harness) HARNESS="$2"; shift 2 ;;
-    --harness=*) HARNESS="${1#--harness=}"; shift ;;
-```
-and initialize `HARNESS=""` next to `WORKER=""`.
-
-In `cmd_launch`/`cmd_adopt`, default it: `local harness="${HARNESS:-claude}"`. Add `--arg harness "$harness"` and `harness: $harness` to the `jq -n` meta builder in both functions.
-
-- [ ] **Step 4: Load the driver centrally in dispatch**
-
-In the dispatch section (after `SUB`/`WORKER` are resolved, before the `case "$SUB"`), add: for per-worker subs, resolve the session and load the driver from meta; for `launch`/`adopt`, load from the flag:
+At the very top of `cmd_launch` (before reading positional `tmux_name`), add:
 
 ```bash
-if is_in "$SUB" "${PER_WORKER_SUBS[@]}"; then
-  _wsid=$(resolve_session "$WORKER") || exit 1
-  _whar=$(jq -r '.harness // "claude"' "/tmp/claude-workers/${_wsid}.meta" 2>/dev/null)
-  _load_driver "${_whar:-claude}"
-elif [ "$SUB" = "launch" ] || [ "$SUB" = "adopt" ]; then
-  _load_driver "${HARNESS:-claude}"
-fi
+  local harness="claude"
+  while [ "${1:-}" = "--harness" ] || [[ "${1:-}" == --harness=* ]]; do
+    if [ "$1" = "--harness" ]; then harness="$2"; shift 2; else harness="${1#--harness=}"; shift; fi
+  done
+  _load_driver "$harness"
 ```
+Add the identical block at the top of `cmd_adopt`. (`_load_driver "$harness"` re-sources over the dispatch default; last source wins.)
 
-Then remove the temporary `_load_driver claude` lines added to `cmd_launch`/`cmd_adopt` in Task 2.
+- [ ] **Step 4: Persist `harness` in the meta**
+
+In both `cmd_launch` and `cmd_adopt`, the `jq -n` meta builder gets a new arg + field: add `--arg harness "$harness"` and `harness: $harness,` to the object.
 
 - [ ] **Step 5: Run the full suite**
 
-Run: `for t in tests/test-*.sh; do echo "== $t =="; bash "$t" || break; done`
-Expected: every script PASS.
+Run: `for t in tests/test-*.sh; do bash "$t" >/dev/null && echo "ok $t" || echo "FAIL $t"; done`
+Expected: every script `ok` (existing launches omit `--harness` → default `claude`).
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add -A && git commit -m "feat(csd): --harness flag, persist harness in meta, central driver load (PRI-2096)"
+git add -A && git commit -m "feat(csd): --harness flag + persist harness in meta (PRI-2096)"
 ```
 
 ---
 
-## Task 8: Rename worker dir to `/tmp/csd-workers` with back-compat symlink
+## Task 9: Rename worker dir to `/tmp/csd-workers` (flip default, migrate emit-event, symlink)
 
 **Files:**
-- Modify: `scripts/_lib.sh`, `scripts/csd`, all `tests/test-csd-*.sh` that reference `/tmp/claude-workers`
-- Test: full suite
+- Modify: `scripts/_lib.sh`, `hooks/emit-event`, all `tests/*.sh` referencing the path, `scripts/csd` (launch/adopt symlink), `SKILL.md`, `README.md`
+- Test: full suite + `test-emit-event.sh`
 
-- [ ] **Step 1: Parameterize the worker dir in `_lib.sh`**
+- [ ] **Step 1: Flip the default in `_lib.sh`**
 
-Replace `_CSD_WORKER_DIR=/tmp/claude-workers` with:
+Replace `_CSD_WORKER_DIR="${CSD_WORKER_DIR:-/tmp/claude-workers}"` — i.e. change the current `_CSD_WORKER_DIR=/tmp/claude-workers` to:
 ```bash
 _CSD_WORKER_DIR="${CSD_WORKER_DIR:-/tmp/csd-workers}"
 ```
 
-- [ ] **Step 2: Replace hardcoded `/tmp/claude-workers` in `csd` with `$_CSD_WORKER_DIR`**
+- [ ] **Step 2: Parameterize `hooks/emit-event`** (it does not source `_lib.sh`)
 
-`csd` hardcodes `/tmp/claude-workers` in many places (meta/events/shim paths, `mkdir -p`). Replace each literal `/tmp/claude-workers` with `$_CSD_WORKER_DIR`. Verify none remain:
-Run: `grep -n '/tmp/claude-workers' skills/driving-claude-code-sessions/scripts/csd`
-Expected: no matches.
-
-- [ ] **Step 3: Create the back-compat symlink at launch/adopt**
-
-In both `cmd_launch` and `cmd_adopt`, where they `mkdir -p "$_CSD_WORKER_DIR" "$_CSD_WORKER_DIR/bin"`, add right after:
+Replace its 3 runtime sites (emit-event:34, 51, 72 — the comment on line 6 may stay or update). Add near the top (after the `set` line):
 ```bash
-  # Back-compat: live workers from older csd baked /tmp/claude-workers shim paths.
+WORKER_DIR="${CSD_WORKER_DIR:-/tmp/csd-workers}"
+```
+Then: line 34 `if [ ! -f "$WORKER_DIR/${SESSION_ID}.meta" ]; then`; line 51 `mkdir -p "$WORKER_DIR"`; line 72 `EVENT_FILE="$WORKER_DIR/${SESSION_ID}.events.jsonl"`.
+
+- [ ] **Step 3: Back-compat symlink that respects an existing real dir**
+
+In `cmd_launch` and `cmd_adopt`, right after `mkdir -p "$_CSD_WORKER_DIR" "$_CSD_WORKER_DIR/bin"`, add:
+
+```bash
+  # Best-effort back-compat: only symlink the legacy path when it doesn't already
+  # exist (a leftover real /tmp/claude-workers dir from older csd is left alone;
+  # relaunch any live pre-upgrade workers after this upgrade).
   if [ "$_CSD_WORKER_DIR" = "/tmp/csd-workers" ] && [ ! -e /tmp/claude-workers ]; then
     ln -s /tmp/csd-workers /tmp/claude-workers 2>/dev/null || true
   fi
@@ -614,60 +654,60 @@ In both `cmd_launch` and `cmd_adopt`, where they `mkdir -p "$_CSD_WORKER_DIR" "$
 
 - [ ] **Step 4: Point the tests at the new dir**
 
-Each integration test sets `WDIR=/tmp/claude-workers` and the fake-claude stubs write to `/tmp/claude-workers`. Update them to the canonical new path. Apply across the suite:
+Rewrite the path across all 16 referencing test files (including `test-csd-converse-diag.sh` and `test-csd-integration.sh`, and the fake-claude heredocs that write the events file):
 ```bash
 grep -rl '/tmp/claude-workers' tests/ | while read -r f; do
   sed -i '' 's#/tmp/claude-workers#/tmp/csd-workers#g' "$f"
 done
+grep -rn '/tmp/claude-workers' tests/ || echo "tests clean"
 ```
-(macOS `sed -i ''`. On the fake-claude heredocs the path is inside single-quoted `<<'BASH'` blocks — the sed still rewrites the literal text, which is correct since those stubs write the events file.)
+Expected: `tests clean`.
 
-- [ ] **Step 5: Run the full suite**
+- [ ] **Step 5: Run the full suite (including emit-event) on a clean machine**
 
-Run: `for t in tests/test-*.sh; do echo "== $t =="; bash "$t" || break; done`
-Expected: every script PASS against `/tmp/csd-workers`.
+```bash
+rm -rf /tmp/csd-workers   # ensure no stale state masks a bug
+for t in tests/test-*.sh; do bash "$t" >/dev/null && echo "ok $t" || echo "FAIL $t"; done
+```
+Expected: every script `ok` — especially `test-emit-event.sh` (now writes/reads `/tmp/csd-workers`) and `test-csd-launch.sh`.
 
-- [ ] **Step 6: Update docs references**
+- [ ] **Step 6: Update user-facing docs**
 
-In `SKILL.md` and `README.md`, the user-facing paths `/tmp/claude-workers/bin/<tmux-name>` become `/tmp/csd-workers/bin/<tmux-name>`. Update with a note that `/tmp/claude-workers` remains a back-compat symlink. (Mechanical; preserve surrounding prose.)
+In `SKILL.md` and `README.md`, change `/tmp/claude-workers/bin/<tmux-name>` → `/tmp/csd-workers/bin/<tmux-name>`, adding a one-line note that `/tmp/claude-workers` remains a best-effort back-compat symlink. Preserve surrounding prose.
 
 - [ ] **Step 7: Commit**
 
 ```bash
-git add -A && git commit -m "refactor(csd): rename worker dir to /tmp/csd-workers + back-compat symlink (PRI-2096)"
+git add -A && git commit -m "refactor(csd): rename worker dir to /tmp/csd-workers + migrate emit-event (PRI-2096)"
 ```
 
 ---
 
 ## Final verification
 
-- [ ] **Run the entire suite green**
+- [ ] **Whole suite green from a clean slate**
 
-Run: `for t in tests/test-*.sh; do echo "== $t =="; bash "$t" || { echo FAILED; break; }; done`
+```bash
+rm -rf /tmp/csd-workers
+for t in tests/test-*.sh; do echo "== $t =="; bash "$t" || { echo FAILED; break; }; done
+```
 Expected: all 19 scripts (18 existing + `test-csd-drivers.sh`) report `0 failed`.
 
 - [ ] **Confirm zero Claude behavior change**
 
-The only user-visible delta is the worker-dir path (`/tmp/csd-workers`, with `/tmp/claude-workers` symlinked) and the new optional `--harness` flag defaulting to `claude`. Every Claude code path runs through the same flags, transcript formula, and jq as before — now sourced from `drivers/claude.sh`.
+Only user-visible deltas: the worker-dir path (`/tmp/csd-workers`, legacy symlinked best-effort) and the new optional `--harness` flag (default `claude`). Every Claude code path runs the same flags, transcript formula, and jq as before — now sourced from `drivers/claude.sh`.
 
 ---
 
 ## Self-Review
 
-**Spec coverage (Phase 1 scope only):**
-- Driver abstraction / slots → Tasks 1–6 (all slots extracted).
-- `control_plane`/`id_strategy` manifest → Task 1.
-- `--harness` selector + persisted in meta → Task 7.
-- `/tmp/claude-workers` → `/tmp/csd-workers` + symlink → Task 8.
-- Per-harness `harness_env_args` (was `_build_worker_env_args`) → Task 2.
-- Native `parse_turn` (no canonical layer) → Task 5.
-- Codex/Pi drivers, `csd poll` → **deferred to Phase 2/3 plans** (explicitly out of scope here).
+**Spec coverage (Phase 1 scope):** slots → Tasks 1,3,4,5,6,7; manifest (`control_plane`/`id_strategy`) → Task 1; `--harness` persisted in meta → Task 8; dir rename + symlink → Task 9; `harness_env_args` → Task 3; native `parse_turn` (no canonical layer) → Task 6. Codex/Pi drivers + `csd poll` → deferred to Phase 2/3 plans (out of scope).
 
-**Placeholder scan:** none — every code step shows complete bash; every test step gives the exact command and expected result.
+**Placeholder scan:** none — every code step is complete; every test step gives the command + expected result.
 
-**Type/name consistency:** slot names are identical across tasks and match the contract table (`harness_id`, `harness_bin`, `harness_control_plane`, `harness_id_strategy`, `harness_quit_keys`, `harness_env_args`, `harness_launch_argv`, `harness_transcript_path`, `harness_parse_turn`, `harness_count_text`, `harness_last_text`). `WORKER_ENV_ARGS` (array out-param), `_CSD_WORKER_DIR`, `_CSD_SCRIPT_DIR`, `_load_driver` are used consistently.
+**Type/name consistency:** slot names match the contract table across all tasks. `WORKER_ENV_ARGS`, `_CSD_WORKER_DIR`, `_CSD_SCRIPT_DIR`, `_load_driver`, `launch_argv`, `parse_full` used consistently.
 
-**Risk flags for the reviewer:**
-- Task 7's central driver-load must run *before* any `cmd_*` references a slot; confirm dispatch order.
-- Task 8's `sed` rewrites paths inside fake-claude heredocs — intended, but worth a careful diff.
-- `mapfile -t` (Task 3) assumes no token contains a newline; true for all current flags (the `--settings` JSON is single-line).
+**Reviewer blockers resolved:** (1) `mapfile` → `while read` loop (Task 4). (2) `${full:+--full}` → `[ "$full" = true ]` array guard (Task 6 Step 3). (3) central driver-load moved to Task 1, before any per-worker slot routing. (4) `emit-event` migrated in Task 9 Step 2. (5) symlink guard documented to leave an existing real dir alone (Task 9 Step 3). (6) worker-dir parameterized to `$_CSD_WORKER_DIR` early (Task 2), default flipped late (Task 9 Step 1). Nit (4) `--harness` parsed after the subcommand to match the spec (Task 8 Step 3). Nits (1)(2): null-cwd guard kept in callers (Task 5), no-prompt stderr kept in the slot (Task 6).
+
+**Residual risk for the executor:** Task 9 must run from a clean `/tmp/csd-workers` (Step 5 removes it first) so a leftover dir can't mask a path bug; the legacy `/tmp/claude-workers` real dir on dev machines means the symlink is intentionally skipped there.
+```

--- a/docs/superpowers/plans/2026-06-05-csd-multiharness-phase1-driver-refactor.md
+++ b/docs/superpowers/plans/2026-06-05-csd-multiharness-phase1-driver-refactor.md
@@ -1,0 +1,673 @@
+# CSD Multi-Harness — Phase 1: Driver Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move Claude's harness-specific knowledge in `csd` behind a per-harness driver abstraction, with **zero Claude behavior change**, so Codex and Pi drivers can plug in later (Phases 2–3).
+
+**Architecture:** A sourced driver file `scripts/drivers/claude.sh` implements a fixed set of *slot functions* (the seven ports from the spec). The `csd` spine calls slots and never names a harness; it loads the driver from the worker's `.meta` (`harness` field, default `claude`) or, for `launch`/`adopt`, from a new `--harness` flag (default `claude`). The existing 18-script test suite is the characterization harness: every extraction keeps it green.
+
+**Tech Stack:** Bash, `jq`, `tmux`. Tests are standalone bash scripts run as `bash tests/test-csd-<name>.sh`; `claude` is mocked via `CSD_CLAUDE_BIN`.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-csd-multiharness-design.md`
+
+**Out of scope (later plans):** Codex driver (Phase 2), Pi driver + `csd poll` tailer (Phase 3).
+
+---
+
+## File Structure
+
+- **Create** `skills/driving-claude-code-sessions/scripts/drivers/claude.sh` — Claude driver; implements all slot functions. One responsibility: encode everything Claude-specific.
+- **Modify** `skills/driving-claude-code-sessions/scripts/_lib.sh` — add `_CSD_SCRIPT_DIR`, `_load_driver`; parameterize `_CSD_WORKER_DIR`.
+- **Modify** `skills/driving-claude-code-sessions/scripts/csd` — route `cmd_launch`/`cmd_adopt`/`cmd_stop`/`cmd_read_turn`/`cmd_converse` through slots; add `--harness` flag; persist `harness` in meta; load the driver in dispatch.
+- **Create** `tests/test-csd-drivers.sh` — unit tests for the driver loader and Claude slot outputs.
+
+### The slot contract (final shape after Phase 1)
+
+```
+harness_id                                    # echoes the harness id, e.g. "claude"
+harness_bin                                   # echoes the resolved binary (honors CSD_<H>_BIN)
+harness_control_plane                         # "hooks" | "poll"
+harness_id_strategy                           # "assign" | "derive"
+harness_quit_keys                             # literal keys to quit the TUI, e.g. "/exit"
+harness_env_args                              # populates array WORKER_ENV_ARGS=(-e VAR=… …)
+harness_launch_argv <mode> <sid> <plugin_dir> # mode=launch|resume; prints argv tokens, one per line
+harness_transcript_path <sid> <cwd>           # echoes the transcript file path
+harness_parse_turn <transcript> [--full]      # native JSONL -> markdown (stdout)
+harness_count_text <transcript>               # echoes count of assistant text messages
+harness_last_text  <transcript>               # echoes the last assistant text block
+```
+
+---
+
+## Task 1: Driver loader + Claude manifest slots
+
+**Files:**
+- Create: `skills/driving-claude-code-sessions/scripts/drivers/claude.sh`
+- Modify: `skills/driving-claude-code-sessions/scripts/_lib.sh`
+- Test: `tests/test-csd-drivers.sh`
+
+- [ ] **Step 1: Write the failing test** — `tests/test-csd-drivers.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCR="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts"
+PASS=0; FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1 - $2"; FAIL=$((FAIL+1)); }
+
+# Load the lib + claude driver in a subshell and probe slot outputs.
+probe() { ( source "$SCR/_lib.sh"; _load_driver claude; "$@" ); }
+
+[ "$(probe harness_id)" = "claude" ] && pass "harness_id=claude" || fail "harness_id" "got $(probe harness_id)"
+[ "$(probe harness_control_plane)" = "hooks" ] && pass "control_plane=hooks" || fail "control_plane" "wrong"
+[ "$(probe harness_id_strategy)" = "assign" ] && pass "id_strategy=assign" || fail "id_strategy" "wrong"
+[ "$(probe harness_quit_keys)" = "/exit" ] && pass "quit_keys=/exit" || fail "quit_keys" "wrong"
+[ "$(probe harness_bin)" = "claude" ] && pass "bin defaults to claude" || fail "bin" "wrong"
+[ "$(CSD_CLAUDE_BIN=/x/claude probe harness_bin)" = "/x/claude" ] && pass "bin honors CSD_CLAUDE_BIN" || fail "bin override" "wrong"
+
+# Unknown harness fails loudly.
+if ( source "$SCR/_lib.sh"; _load_driver nope ) 2>/dev/null; then fail "unknown driver" "should have failed"; else pass "unknown driver errors"; fi
+
+echo "drivers: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `bash tests/test-csd-drivers.sh`
+Expected: FAIL — `_load_driver: command not found` (lib doesn't define it yet).
+
+- [ ] **Step 3: Add loader + script-dir to `_lib.sh`**
+
+At the top of `_lib.sh`, after the header comment and before `_CSD_WORKER_DIR=`, add:
+
+```bash
+# Absolute path to scripts/ (this file's directory). Used to locate drivers/.
+_CSD_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source the harness driver for <harness> (default claude). Driver files live at
+# scripts/drivers/<harness>.sh and define the harness slot functions.
+_load_driver() {
+  local harness="${1:-claude}"
+  local driver_file="$_CSD_SCRIPT_DIR/drivers/${harness}.sh"
+  if [ ! -f "$driver_file" ]; then
+    echo "Error: no driver for harness '$harness' (expected $driver_file)" >&2
+    return 1
+  fi
+  # shellcheck source=/dev/null
+  source "$driver_file"
+}
+```
+
+- [ ] **Step 4: Create `drivers/claude.sh` with the manifest slots**
+
+```bash
+#!/bin/bash
+# Claude Code harness driver for csd. Sourced, not executed. Implements the
+# harness slot contract (see docs/superpowers/specs/2026-06-05-csd-multiharness-design.md).
+
+harness_id()            { echo "claude"; }
+harness_bin()           { echo "${CSD_CLAUDE_BIN:-claude}"; }
+harness_control_plane() { echo "hooks"; }
+harness_id_strategy()   { echo "assign"; }
+harness_quit_keys()     { echo "/exit"; }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `bash tests/test-csd-drivers.sh`
+Expected: PASS — all 7 assertions, `drivers: 7 passed, 0 failed`.
+
+- [ ] **Step 6: Verify existing suite still green** (csd doesn't call the loader yet, so nothing should change)
+
+Run: `bash tests/test-csd-skeleton.sh && bash tests/test-csd-launch.sh`
+Expected: PASS for both.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/driving-claude-code-sessions/scripts/drivers/claude.sh \
+        skills/driving-claude-code-sessions/scripts/_lib.sh tests/test-csd-drivers.sh
+git commit -m "refactor(csd): add driver loader + claude manifest slots (PRI-2096)"
+```
+
+---
+
+## Task 2: Extract `harness_env_args`
+
+Moves the provider-env pinning (`_PROVIDER_ENV_VARS` + `_build_worker_env_args`, csd lines ~665–691) into the driver. The spine calls `harness_env_args` instead.
+
+**Files:**
+- Modify: `drivers/claude.sh`
+- Modify: `scripts/csd` (remove `_PROVIDER_ENV_VARS`/`_build_worker_env_args`; call `harness_env_args`)
+- Test: `tests/test-csd-drivers.sh`, `tests/test-csd-provider-env.sh`
+
+- [ ] **Step 1: Add the failing slot assertions** — append to `tests/test-csd-drivers.sh` before the final echo:
+
+```bash
+# harness_env_args populates WORKER_ENV_ARGS; SSE_PORT always pinned empty,
+# an UNSET provider var is pinned empty, a SET one is left to inherit.
+envprobe() { ( source "$SCR/_lib.sh"; _load_driver claude; "$@"; harness_env_args; printf '%s\n' "${WORKER_ENV_ARGS[@]}" ); }
+out=$(unset CLAUDE_CODE_USE_BEDROCK; envprobe true)
+echo "$out" | grep -qx -- "-e" && echo "$out" | grep -qx "CLAUDE_CODE_SSE_PORT=" && pass "env: SSE_PORT pinned" || fail "env SSE_PORT" "missing"
+echo "$out" | grep -qx "CLAUDE_CODE_USE_BEDROCK=" && pass "env: unset bedrock pinned empty" || fail "env bedrock unset" "missing"
+out2=$(CLAUDE_CODE_USE_BEDROCK=1 envprobe true)
+echo "$out2" | grep -qx "CLAUDE_CODE_USE_BEDROCK=" && fail "env set-bedrock" "should NOT pin a set var" || pass "env: set bedrock left to inherit"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash tests/test-csd-drivers.sh`
+Expected: FAIL — `harness_env_args: command not found`.
+
+- [ ] **Step 3: Add `harness_env_args` to `drivers/claude.sh`** (append):
+
+```bash
+# Provider/auth vars Claude resolves from the process env (issue #18). Pinned
+# empty when unset in this process (kills stale tmux-global values); left to
+# inherit when set here (so credentials travel with the selector).
+_CLAUDE_PROVIDER_ENV_VARS=(
+  CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
+  CLAUDE_CODE_USE_BEDROCK
+  CLAUDE_CODE_USE_VERTEX
+  CLAUDE_CODE_USE_FOUNDRY
+  CLAUDE_CODE_USE_ANTHROPIC_AWS
+  CLAUDE_CODE_USE_MANTLE
+)
+
+# Populate the caller-declared WORKER_ENV_ARGS array with -e VAR=… pairs.
+harness_env_args() {
+  WORKER_ENV_ARGS=(-e "CLAUDE_CODE_SSE_PORT=")
+  local var val
+  for var in "${_CLAUDE_PROVIDER_ENV_VARS[@]}"; do
+    val=$(printenv "$var" 2>/dev/null) || val=""
+    if [ -z "$val" ]; then
+      WORKER_ENV_ARGS+=(-e "${var}=")
+    fi
+  done
+}
+```
+
+- [ ] **Step 4: Remove the originals from `csd` and call the slot**
+
+In `csd`, delete the `_PROVIDER_ENV_VARS=(...)` array (and its long comment block, ~lines 617–672) and the `_build_worker_env_args() { ... }` function (~lines 674–691). In `cmd_launch` and `cmd_adopt`, replace the two lines:
+
+```bash
+  local WORKER_ENV_ARGS=()
+  _build_worker_env_args
+```
+with:
+```bash
+  local WORKER_ENV_ARGS=()
+  harness_env_args
+```
+
+(The driver is loaded in dispatch — Task 7 — but for now add a temporary `_load_driver claude` at the top of `cmd_launch`/`cmd_adopt` just before `harness_env_args`; Task 7 removes these temporary loads when dispatch loads the driver centrally.)
+
+- [ ] **Step 5: Run tests to verify green**
+
+Run: `bash tests/test-csd-drivers.sh && bash tests/test-csd-provider-env.sh && bash tests/test-csd-launch.sh`
+Expected: PASS for all three.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "refactor(csd): move provider-env pinning into harness_env_args slot (PRI-2096)"
+```
+
+---
+
+## Task 3: Extract `harness_launch_argv` (launch + resume)
+
+Moves the `claude --session-id … --plugin-dir … --dangerously-skip-permissions --disallowed-tools AskUserQuestion` construction (csd ~757–763) and the `--resume` variant (cmd_adopt ~861–876) into one slot taking a `mode` of `launch` or `resume`.
+
+**Files:**
+- Modify: `drivers/claude.sh`, `scripts/csd`
+- Test: `tests/test-csd-drivers.sh`, `tests/test-csd-launch.sh`, `tests/test-csd-adopt.sh`
+
+- [ ] **Step 1: Add failing slot assertions** — append to `tests/test-csd-drivers.sh`:
+
+```bash
+argv_launch=$( ( source "$SCR/_lib.sh"; _load_driver claude; harness_launch_argv launch SID123 /plug ) )
+echo "$argv_launch" | head -1 | grep -qx "claude" && pass "launch argv starts with bin" || fail "launch argv bin" "wrong"
+echo "$argv_launch" | grep -qx -- "--session-id" && echo "$argv_launch" | grep -qx "SID123" && pass "launch uses --session-id" || fail "launch sid" "wrong"
+echo "$argv_launch" | grep -qx -- "--dangerously-skip-permissions" && pass "launch bypass flag" || fail "bypass" "wrong"
+echo "$argv_launch" | grep -qx "AskUserQuestion" && pass "launch disallows AskUserQuestion" || fail "disallow" "wrong"
+argv_resume=$( ( source "$SCR/_lib.sh"; _load_driver claude; harness_launch_argv resume SID123 /plug ) )
+echo "$argv_resume" | grep -qx -- "--resume" && pass "resume uses --resume" || fail "resume" "wrong"
+echo "$argv_resume" | grep -qx -- "--session-id" && fail "resume sid" "should not use --session-id" || pass "resume omits --session-id"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash tests/test-csd-drivers.sh`
+Expected: FAIL — `harness_launch_argv: command not found`.
+
+- [ ] **Step 3: Add `harness_launch_argv` to `drivers/claude.sh`** (append):
+
+```bash
+# Print the harness command + flags (one token per line) for `mode`:
+#   launch -> --session-id <sid>;  resume -> --resume <sid>
+# The spine wraps this with tmux + env args + any user extra-args.
+harness_launch_argv() {
+  local mode="$1" sid="$2" plugin_dir="$3"
+  local bin; bin=$(harness_bin)
+  local idflag="--session-id"
+  [ "$mode" = "resume" ] && idflag="--resume"
+  printf '%s\n' \
+    "$bin" "$idflag" "$sid" --plugin-dir "$plugin_dir" \
+    --settings '{"skipDangerousModePermissionPrompt":true}' \
+    --dangerously-skip-permissions \
+    --disallowed-tools AskUserQuestion
+}
+```
+
+- [ ] **Step 4: Route `cmd_launch` through the slot**
+
+In `cmd_launch`, replace the `tmux new-session` block (the `local claude_bin=…` line through the closing `"${extra_args[@]+...}"`, ~754–763) with:
+
+```bash
+  local launch_argv=()
+  mapfile -t launch_argv < <(harness_launch_argv launch "$session_id" "$plugin_dir")
+  local WORKER_ENV_ARGS=()
+  harness_env_args
+  tmux new-session -d -s "$tmux_name" -c "$working_dir" \
+    "${WORKER_ENV_ARGS[@]}" \
+    "${launch_argv[@]}" \
+    "${extra_args[@]+"${extra_args[@]}"}"
+```
+
+(Removes the now-unused `local claude_bin=…`.)
+
+- [ ] **Step 5: Route `cmd_adopt` through the slot**
+
+In `cmd_adopt`, both branches (`respawn-pane` and `new-session`) construct the claude argv inline. Replace the `local claude_bin=…` + `_build_worker_env_args` lines and both inline argv lists so each tmux call uses:
+
+```bash
+  local launch_argv=()
+  mapfile -t launch_argv < <(harness_launch_argv resume "$session_id" "$plugin_dir")
+  local WORKER_ENV_ARGS=()
+  harness_env_args
+```
+then in the respawn branch:
+```bash
+    tmux respawn-pane -k -t "$tmux_name" -c "$working_dir" \
+      "${WORKER_ENV_ARGS[@]}" "${launch_argv[@]}" \
+      "${extra_args[@]+"${extra_args[@]}"}"
+```
+and the new-session branch:
+```bash
+    tmux new-session -d -s "$tmux_name" -c "$working_dir" \
+      "${WORKER_ENV_ARGS[@]}" "${launch_argv[@]}" \
+      "${extra_args[@]+"${extra_args[@]}"}"
+```
+
+- [ ] **Step 6: Run tests to verify green**
+
+Run: `bash tests/test-csd-drivers.sh && bash tests/test-csd-launch.sh && bash tests/test-csd-adopt.sh`
+Expected: PASS for all three.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "refactor(csd): route launch/adopt through harness_launch_argv slot (PRI-2096)"
+```
+
+---
+
+## Task 4: Extract `harness_transcript_path`
+
+Moves the `$HOME/.claude/projects/${cwd//\//-}/${sid}.jsonl` derivation (duplicated in `cmd_read_turn` ~298–309 and `cmd_converse` ~368–379) into one slot.
+
+**Files:**
+- Modify: `drivers/claude.sh`, `scripts/csd`
+- Test: `tests/test-csd-drivers.sh`, `tests/test-csd-read-turn.sh`, `tests/test-csd-converse.sh`
+
+- [ ] **Step 1: Add failing assertion** — append to `tests/test-csd-drivers.sh`:
+
+```bash
+tp=$( ( source "$SCR/_lib.sh"; _load_driver claude; HOME=/home/x harness_transcript_path SID /a/b ) )
+[ "$tp" = "/home/x/.claude/projects/-a-b/SID.jsonl" ] && pass "transcript_path formula" || fail "transcript_path" "got $tp"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash tests/test-csd-drivers.sh`
+Expected: FAIL — `harness_transcript_path: command not found`.
+
+- [ ] **Step 3: Add the slot to `drivers/claude.sh`** (append):
+
+```bash
+# Echo the transcript path for <sid> in <cwd>. Resolves cwd to absolute first
+# (matches the spine's prior behavior).
+harness_transcript_path() {
+  local sid="$1" cwd="$2"
+  if [ -d "$cwd" ]; then cwd=$(cd "$cwd" && pwd -P); fi
+  local encoded="${cwd//\//-}"
+  echo "$HOME/.claude/projects/${encoded}/${sid}.jsonl"
+}
+```
+
+- [ ] **Step 4: Route the spine through the slot**
+
+In `cmd_read_turn`, replace the `cwd=…`/`encoded=…`/`log_file=…` derivation (the block computing `log_file`, ~300–309) with:
+
+```bash
+  local log_file
+  log_file=$(harness_transcript_path "$sid" "$(jq -r '.cwd' "/tmp/claude-workers/${sid}.meta")")
+```
+
+In `cmd_converse`, replace the analogous `cwd=…`/`encoded=…`/`log_file=…` block (~370–379) with the same two lines (keep the separate `event_file=…` line that follows).
+
+- [ ] **Step 5: Run tests to verify green**
+
+Run: `bash tests/test-csd-drivers.sh && bash tests/test-csd-read-turn.sh && bash tests/test-csd-converse.sh`
+Expected: PASS for all three.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "refactor(csd): move transcript-path formula into slot (PRI-2096)"
+```
+
+---
+
+## Task 5: Extract `harness_parse_turn`, `harness_count_text`, `harness_last_text`
+
+Moves the big `jq` turn-renderer (`cmd_read_turn` ~316–356) and the two converse helpers (`count_text_messages`, `last_text_response`, ~382–392) into the driver.
+
+**Files:**
+- Modify: `drivers/claude.sh`, `scripts/csd`
+- Test: `tests/test-csd-read-turn.sh`, `tests/test-csd-converse.sh`, `tests/test-csd-readers.sh`
+
+- [ ] **Step 1: Run the existing readers suite as the baseline (must already pass)**
+
+Run: `bash tests/test-csd-read-turn.sh && bash tests/test-csd-readers.sh && bash tests/test-csd-converse.sh`
+Expected: PASS — this is the characterization baseline this task must preserve.
+
+- [ ] **Step 2: Add the three slots to `drivers/claude.sh`** (append). `harness_parse_turn` takes the transcript path and optional `--full`; it reproduces the current renderer verbatim (find last real user prompt line, then render assistant/user records):
+
+```bash
+# Render the last turn of <transcript> as markdown. With --full, tool results
+# are shown complete; otherwise truncated to 5 lines.
+harness_parse_turn() {
+  local log_file="$1" full=false
+  [ "${2:-}" = "--full" ] && full=true
+  local last_prompt_line
+  last_prompt_line=$(grep -n '"type":"user"' "$log_file" \
+    | grep -v '"tool_result"' | grep -v '<local-command' | grep -v '<command-name>' \
+    | tail -1 | cut -d: -f1)
+  [ -z "$last_prompt_line" ] && return 1
+  tail -n +"$last_prompt_line" "$log_file" \
+    | jq -r --argjson full "$full" '
+      select(.type == "assistant" or .type == "user") |
+      if .type == "user" then
+        if (.message.content | type) == "string" then
+          if (.message.content | test("^<(local-command|command-name)")) then empty
+          else "---\n\n**Prompt:** " + .message.content + "\n" end
+        else
+          .message.content[] | select(.type == "tool_result") |
+          if .is_error then
+            "**Tool Error:**\n```\n" + (.content // "(no output)") + "\n```\n"
+          else
+            if $full then
+              "**Result:**\n```\n" + (.content // "(no output)") + "\n```\n"
+            else
+              "**Result:**\n```\n" + ((.content // "(no output)") | split("\n") | if length > 5 then (.[0:5] | join("\n")) + "\n... (" + (length | tostring) + " lines total)" else join("\n") end) + "\n```\n"
+            end
+          end
+        end
+      elif .type == "assistant" then
+        .message.content[] |
+        if .type == "thinking" then "> **Thinking:** " + (.thinking | split("\n") | join("\n> ")) + "\n"
+        elif .type == "text" then .text + "\n"
+        elif .type == "tool_use" then "**Tool: " + .name + "**\n```json\n" + (.input | tostring) + "\n```\n"
+        else empty
+        end
+      else empty
+      end
+    ' 2>/dev/null
+}
+
+# Echo the count of assistant messages that contain a text block.
+harness_count_text() {
+  local log_file="$1"
+  [ -f "$log_file" ] || { echo 0; return; }
+  local r
+  r=$(grep '"type":"assistant"' "$log_file" \
+      | jq -s '[.[] | select(.message.content | (type == "array") and any(.type == "text"))] | length' 2>/dev/null) || r=0
+  echo "$r"
+}
+
+# Echo the text of the last assistant message that has a text block.
+harness_last_text() {
+  local log_file="$1"
+  grep '"type":"assistant"' "$log_file" \
+    | jq -rs 'map(select(.message.content | (type == "array") and any(.type == "text"))) | last | [.message.content[] | select(.type == "text") | .text] | join("\n")' 2>/dev/null
+}
+```
+
+- [ ] **Step 3: Route `cmd_read_turn` through the slot**
+
+Replace the body of `cmd_read_turn` after `log_file` is resolved (the `if [ ! -f "$log_file" ]` check stays) — replace the `last_prompt_line=…` block plus the trailing `tail … | jq …` (~316–356) with:
+
+```bash
+  harness_parse_turn "$log_file" ${full:+--full}
+```
+(Keep `full` parsing at the top of `cmd_read_turn`.)
+
+- [ ] **Step 4: Route `cmd_converse` through the slots**
+
+In `cmd_converse`, delete the inline `count_text_messages()` and `last_text_response()` function definitions (~382–392). Replace their call sites: `before_count=$(count_text_messages)` → `before_count=$(harness_count_text "$log_file")`; `after_count=$(count_text_messages)` → `after_count=$(harness_count_text "$log_file")`; `response=$(last_text_response)` → `response=$(harness_last_text "$log_file")`.
+
+- [ ] **Step 5: Run tests to verify green**
+
+Run: `bash tests/test-csd-read-turn.sh && bash tests/test-csd-readers.sh && bash tests/test-csd-converse.sh && bash tests/test-csd-converse-diag.sh`
+Expected: PASS for all four.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "refactor(csd): move turn parsing + converse text helpers into slots (PRI-2096)"
+```
+
+---
+
+## Task 6: Route `cmd_stop` through `harness_quit_keys`
+
+**Files:**
+- Modify: `scripts/csd`
+- Test: `tests/test-csd-stop.sh`
+
+- [ ] **Step 1: Baseline** — Run: `bash tests/test-csd-stop.sh` → Expected: PASS.
+
+- [ ] **Step 2: Replace the literal `/exit` in `cmd_stop`**
+
+In `cmd_stop`, replace:
+```bash
+    tmux send-keys -t "$tmux_name" -l '/exit'
+    tmux send-keys -t "$tmux_name" Enter
+```
+with:
+```bash
+    tmux send-keys -t "$tmux_name" -l "$(harness_quit_keys)"
+    tmux send-keys -t "$tmux_name" Enter
+```
+
+- [ ] **Step 3: Run test to verify green**
+
+Run: `bash tests/test-csd-stop.sh`
+Expected: PASS (Claude's `harness_quit_keys` is `/exit`, unchanged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "refactor(csd): stop uses harness_quit_keys slot (PRI-2096)"
+```
+
+---
+
+## Task 7: `--harness` flag, persist in meta, load driver in dispatch
+
+Makes the harness a first-class, persisted axis (default `claude`), and centralizes driver loading so the temporary `_load_driver claude` calls from Task 2 are removed.
+
+**Files:**
+- Modify: `scripts/csd`
+- Test: `tests/test-csd-launch.sh`, `tests/test-csd-drivers.sh`, full suite
+
+- [ ] **Step 1: Add a failing test** — append to `tests/test-csd-drivers.sh`:
+
+```bash
+# After a launch, the meta records harness=claude (back-compat default).
+# (Reuses the fake-claude pattern; minimal inline check.)
+FAKE_HOME=$(mktemp -d); mkdir -p "$FAKE_HOME/.claude"; touch "$FAKE_HOME/.claude/.claude-session-driver-consent"
+FAKE_CLAUDE=$(mktemp); cat > "$FAKE_CLAUDE" <<'B'
+#!/bin/bash
+SID=""; while [ $# -gt 0 ]; do case "$1" in --session-id) SID="$2"; shift 2;; *) shift;; esac; done
+mkdir -p /tmp/claude-workers
+echo "{\"ts\":\"x\",\"event\":\"session_start\",\"cwd\":\"$PWD\"}" > "/tmp/claude-workers/${SID}.events.jsonl"; exec sleep 30
+B
+chmod +x "$FAKE_CLAUDE"
+TN="test-drivers-meta-$$"
+SHIM=$(CSD_CLAUDE_BIN="$FAKE_CLAUDE" HOME="$FAKE_HOME" bash "$SCR/csd" launch "$TN" /tmp 2>/dev/null)
+SID=$(basename "$(grep -l "\"tmux_name\":\"$TN\"" /tmp/claude-workers/*.meta)" .meta)
+[ "$(jq -r '.harness' "/tmp/claude-workers/$SID.meta")" = "claude" ] && pass "meta records harness=claude" || fail "meta harness" "wrong"
+tmux kill-session -t "$TN" 2>/dev/null || true; rm -f "/tmp/claude-workers/$SID".* "/tmp/claude-workers/bin/$TN"; rm -rf "$FAKE_HOME" "$FAKE_CLAUDE"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash tests/test-csd-drivers.sh`
+Expected: FAIL — `.harness` is `null` (meta has no harness field yet).
+
+- [ ] **Step 3: Parse `--harness` in `cmd_launch`/`cmd_adopt` and persist it**
+
+At the top of `cmd_launch` (and `cmd_adopt`), after the existing positional parsing, add harness parsing. Simplest: support `--harness <name>` immediately after the subcommand. In the main arg parser is cleaner — add a top-level `HARNESS` var alongside `WORKER`:
+
+In the main `while` loop that parses `--worker`, add cases:
+```bash
+    --harness) HARNESS="$2"; shift 2 ;;
+    --harness=*) HARNESS="${1#--harness=}"; shift ;;
+```
+and initialize `HARNESS=""` next to `WORKER=""`.
+
+In `cmd_launch`/`cmd_adopt`, default it: `local harness="${HARNESS:-claude}"`. Add `--arg harness "$harness"` and `harness: $harness` to the `jq -n` meta builder in both functions.
+
+- [ ] **Step 4: Load the driver centrally in dispatch**
+
+In the dispatch section (after `SUB`/`WORKER` are resolved, before the `case "$SUB"`), add: for per-worker subs, resolve the session and load the driver from meta; for `launch`/`adopt`, load from the flag:
+
+```bash
+if is_in "$SUB" "${PER_WORKER_SUBS[@]}"; then
+  _wsid=$(resolve_session "$WORKER") || exit 1
+  _whar=$(jq -r '.harness // "claude"' "/tmp/claude-workers/${_wsid}.meta" 2>/dev/null)
+  _load_driver "${_whar:-claude}"
+elif [ "$SUB" = "launch" ] || [ "$SUB" = "adopt" ]; then
+  _load_driver "${HARNESS:-claude}"
+fi
+```
+
+Then remove the temporary `_load_driver claude` lines added to `cmd_launch`/`cmd_adopt` in Task 2.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `for t in tests/test-*.sh; do echo "== $t =="; bash "$t" || break; done`
+Expected: every script PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(csd): --harness flag, persist harness in meta, central driver load (PRI-2096)"
+```
+
+---
+
+## Task 8: Rename worker dir to `/tmp/csd-workers` with back-compat symlink
+
+**Files:**
+- Modify: `scripts/_lib.sh`, `scripts/csd`, all `tests/test-csd-*.sh` that reference `/tmp/claude-workers`
+- Test: full suite
+
+- [ ] **Step 1: Parameterize the worker dir in `_lib.sh`**
+
+Replace `_CSD_WORKER_DIR=/tmp/claude-workers` with:
+```bash
+_CSD_WORKER_DIR="${CSD_WORKER_DIR:-/tmp/csd-workers}"
+```
+
+- [ ] **Step 2: Replace hardcoded `/tmp/claude-workers` in `csd` with `$_CSD_WORKER_DIR`**
+
+`csd` hardcodes `/tmp/claude-workers` in many places (meta/events/shim paths, `mkdir -p`). Replace each literal `/tmp/claude-workers` with `$_CSD_WORKER_DIR`. Verify none remain:
+Run: `grep -n '/tmp/claude-workers' skills/driving-claude-code-sessions/scripts/csd`
+Expected: no matches.
+
+- [ ] **Step 3: Create the back-compat symlink at launch/adopt**
+
+In both `cmd_launch` and `cmd_adopt`, where they `mkdir -p "$_CSD_WORKER_DIR" "$_CSD_WORKER_DIR/bin"`, add right after:
+```bash
+  # Back-compat: live workers from older csd baked /tmp/claude-workers shim paths.
+  if [ "$_CSD_WORKER_DIR" = "/tmp/csd-workers" ] && [ ! -e /tmp/claude-workers ]; then
+    ln -s /tmp/csd-workers /tmp/claude-workers 2>/dev/null || true
+  fi
+```
+
+- [ ] **Step 4: Point the tests at the new dir**
+
+Each integration test sets `WDIR=/tmp/claude-workers` and the fake-claude stubs write to `/tmp/claude-workers`. Update them to the canonical new path. Apply across the suite:
+```bash
+grep -rl '/tmp/claude-workers' tests/ | while read -r f; do
+  sed -i '' 's#/tmp/claude-workers#/tmp/csd-workers#g' "$f"
+done
+```
+(macOS `sed -i ''`. On the fake-claude heredocs the path is inside single-quoted `<<'BASH'` blocks — the sed still rewrites the literal text, which is correct since those stubs write the events file.)
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `for t in tests/test-*.sh; do echo "== $t =="; bash "$t" || break; done`
+Expected: every script PASS against `/tmp/csd-workers`.
+
+- [ ] **Step 6: Update docs references**
+
+In `SKILL.md` and `README.md`, the user-facing paths `/tmp/claude-workers/bin/<tmux-name>` become `/tmp/csd-workers/bin/<tmux-name>`. Update with a note that `/tmp/claude-workers` remains a back-compat symlink. (Mechanical; preserve surrounding prose.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "refactor(csd): rename worker dir to /tmp/csd-workers + back-compat symlink (PRI-2096)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the entire suite green**
+
+Run: `for t in tests/test-*.sh; do echo "== $t =="; bash "$t" || { echo FAILED; break; }; done`
+Expected: all 19 scripts (18 existing + `test-csd-drivers.sh`) report `0 failed`.
+
+- [ ] **Confirm zero Claude behavior change**
+
+The only user-visible delta is the worker-dir path (`/tmp/csd-workers`, with `/tmp/claude-workers` symlinked) and the new optional `--harness` flag defaulting to `claude`. Every Claude code path runs through the same flags, transcript formula, and jq as before — now sourced from `drivers/claude.sh`.
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 scope only):**
+- Driver abstraction / slots → Tasks 1–6 (all slots extracted).
+- `control_plane`/`id_strategy` manifest → Task 1.
+- `--harness` selector + persisted in meta → Task 7.
+- `/tmp/claude-workers` → `/tmp/csd-workers` + symlink → Task 8.
+- Per-harness `harness_env_args` (was `_build_worker_env_args`) → Task 2.
+- Native `parse_turn` (no canonical layer) → Task 5.
+- Codex/Pi drivers, `csd poll` → **deferred to Phase 2/3 plans** (explicitly out of scope here).
+
+**Placeholder scan:** none — every code step shows complete bash; every test step gives the exact command and expected result.
+
+**Type/name consistency:** slot names are identical across tasks and match the contract table (`harness_id`, `harness_bin`, `harness_control_plane`, `harness_id_strategy`, `harness_quit_keys`, `harness_env_args`, `harness_launch_argv`, `harness_transcript_path`, `harness_parse_turn`, `harness_count_text`, `harness_last_text`). `WORKER_ENV_ARGS` (array out-param), `_CSD_WORKER_DIR`, `_CSD_SCRIPT_DIR`, `_load_driver` are used consistently.
+
+**Risk flags for the reviewer:**
+- Task 7's central driver-load must run *before* any `cmd_*` references a slot; confirm dispatch order.
+- Task 8's `sed` rewrites paths inside fake-claude heredocs — intended, but worth a careful diff.
+- `mapfile -t` (Task 3) assumes no token contains a newline; true for all current flags (the `--settings` JSON is single-line).

--- a/docs/superpowers/plans/2026-06-05-csd-multiharness-phase2-codex.md
+++ b/docs/superpowers/plans/2026-06-05-csd-multiharness-phase2-codex.md
@@ -613,3 +613,58 @@ git commit -m "test(csd): gated real-codex end-to-end smoke (PRI-2096)"
 - The fake fires hooks at boot (not on a prompt); the real flow fires at first prompt. The integration test therefore can't exercise the `send`-triggered registration timing — Task 7 (real) covers that. Flag if a fake that fires on a sent prompt is worth the extra complexity.
 - Codex `harness_env_args` REPLACES the Claude provider-env pinning for codex workers (different isolation lever) — confirm that's intended (it is: CODEX_HOME is codex's isolation, not the CLAUDE_CODE_* vars).
 - `harness_await_ready` greps the pane for `›` — brittle if the codex TUI glyph differs by version; it's best-effort (the first send re-confirms), but note it.
+
+---
+
+## Revisions from Riker's review (verified in bash 3.2; fold into the tasks above)
+
+**B1 (blocking) — the dispatcher gate kills the derive window.** `csd:878`
+`_wsid=$(resolve_session "$WORKER") || exit 1` runs *before* `cmd_send`, so a
+pre-registration derive worker `exit 1`s before it can self-register. Fix in two
+places:
+- **Task 4 / `cmd_launch`** (all harnesses): right after the `mkdir -p
+  "$_CSD_WORKER_DIR" …`, drop a sidecar marker: `printf '%s' "$harness" >
+  "$_CSD_WORKER_DIR/${tmux_name}.harness"`.
+- **The dispatcher block** (csd ~877) becomes:
+```bash
+if is_in "$SUB" "${PER_WORKER_SUBS[@]}"; then
+  _wsid=$(resolve_session "$WORKER" 2>/dev/null) || _wsid=""
+  if [ -n "$_wsid" ] && [ -f "$_CSD_WORKER_DIR/${_wsid}.meta" ]; then
+    _whar=$(jq -r '.harness // "claude"' "$_CSD_WORKER_DIR/${_wsid}.meta" 2>/dev/null)
+  elif [ -f "$_CSD_WORKER_DIR/${WORKER}.harness" ]; then
+    _whar=$(cat "$_CSD_WORKER_DIR/${WORKER}.harness")   # derive pre-registration window
+  else
+    echo "Error: no worker known as '$WORKER'" >&2; exit 1
+  fi
+  _load_driver "${_whar:-claude}"
+elif [ "$SUB" = "launch" ] || [ "$SUB" = "adopt" ]; then
+  _load_driver "${HARNESS:-claude}"
+fi
+```
+- **`cmd_stop`** cleanup: add `rm -f "$_CSD_WORKER_DIR/${tmux_name}.harness"` and
+  `rm -rf "$_CSD_WORKER_DIR/homes/${tmux_name}"`.
+
+**B2 (blocking) — `emit-event-codex` must read with `-r`.** Change `IFS= read -t 5
+-d '' INPUT` → `IFS= read -t 5 -d '' -r INPUT` (matches `hooks/emit-event:25`;
+without it, escaped JSON in `tool_input` is mangled → silent bail). Add a Task-2
+test payload with `\"` and `\n` inside `tool_input`.
+
+**B3 (blocking) — `set -u` abort + adopt scope.** codex `harness_env_args`:
+`WORKER_ENV_ARGS=(-e "CODEX_HOME=${_CSD_CURRENT_WORKER_HOME:-}")`. And `cmd_adopt`
+is assign-only — after its `--harness` parse + `_load_driver`, add:
+`[ "$(harness_id_strategy)" = assign ] || { echo "Error: adopt supports only
+assign-id harnesses (claude)" >&2; return 1; }`.
+
+**B4 (blocking) — `grep -c` double-zero.** codex `harness_count_text`:
+`local c; c=$(grep -c '"agent_message"' "$rollout" 2>/dev/null) || c=0; echo "$c"`
+(the `… || echo 0` form prints `0\n0` on no-match and breaks `-gt`).
+
+**N1 — map `PostToolUse` explicitly** in the `emit-event-codex` case
+(`PostToolUse) e=post_tool_use ;;`) so the GNU-only `\L` sed fallback never fires
+(BSD/macOS sed emits a literal `L`).
+
+**N4 — gate the collision-check `rm`** in `cmd_launch` on `[ -n "$session_id" ]`
+(empty sid for derive otherwise `rm -f …/.meta`).
+
+**N5 — `cmd_converse` derive path:** set `after_line=0` and `before_count=0`
+before `wait_for_turn` (the events file is brand-new at registration).

--- a/docs/superpowers/plans/2026-06-05-csd-multiharness-phase2-codex.md
+++ b/docs/superpowers/plans/2026-06-05-csd-multiharness-phase2-codex.md
@@ -1,0 +1,615 @@
+# CSD Multi-Harness — Phase 2: Codex Driver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drive **Codex** workers through `csd` — same controller-facing contract as Claude — by adding the `derive`-id identity flow + a self-registering Codex hook, reusing the existing `events.jsonl` control plane.
+
+**Architecture:** Codex mints its own session id (no `--session-id`). A per-worker `CODEX_HOME` holds a generated `config.toml` whose lifecycle hooks run **`emit-event-codex`**, which *self-registers* `<sid>.meta` and appends the normalized `<sid>.events.jsonl` from the SessionStart payload. Once registered, every downstream command (`wait-for-turn`/`status`/`read-events`/`converse`) works **unchanged** from Phase 1. The one new spine behavior is tolerating the **pre-registration window** (launch → first prompt). This entire flow is **validated end-to-end against real codex 0.134** (spec Appendix B).
+
+**Tech Stack:** Bash 3.2 (no `mapfile`/assoc arrays), `jq`, `tmux`, `codex` CLI. Codex mocked in tests via `CSD_CODEX_BIN` → a fake that simulates the self-registering hooks + a rollout.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-csd-multiharness-design.md` (esp. **Appendix B**).
+
+**Depends on:** Phase 1 (driver slots, `/tmp/csd-workers`, `--harness`). **Out of scope:** Pi (Phase 3) — but the derive-id spine built here is reused by Pi.
+
+---
+
+## File Structure
+
+- **Create** `scripts/drivers/codex.sh` — Codex driver slots.
+- **Create** `hooks/emit-event-codex` — self-registering hook (the validated prototype script).
+- **Modify** `scripts/csd` — `cmd_launch` branches on `harness_id_strategy`; new slot calls (`harness_prepare`, `harness_post_launch`, `harness_await_ready`); pre-registration tolerance in `cmd_send`/`cmd_converse`.
+- **Modify** `scripts/drivers/claude.sh` — widen `harness_launch_argv` signature; add no-op `harness_prepare`/`harness_post_launch`/`harness_await_ready`.
+- **Modify** `scripts/_lib.sh` — add `_worker_tmux_name` helper (resolves the tmux session name without requiring a registered sid).
+- **Create** `tests/fixtures/fake-codex` — simulates codex: on launch, fires the configured hooks with synthetic payloads + writes a minimal rollout.
+- **Create** `tests/test-csd-codex.sh` — driver unit tests + a fake-codex integration test (launch → converse → read-turn).
+- **Create** `tests/test-emit-event-codex.sh` — hook self-registration unit test.
+
+### Slot contract additions (extends Phase 1)
+
+```
+harness_launch_argv <mode> <sid> <cwd> <plugin_dir> <worker_home>   # WIDENED (was <mode> <sid> <plugin_dir>)
+harness_prepare     <tmux_name> <cwd> <worker_home>                 # set up per-worker config; "" = nothing
+harness_post_launch <tmux_name>                                     # dismiss startup gates; "" = nothing
+harness_await_ready <tmux_name> <session_id_or_empty>               # assign: session_start; derive: composer/settle
+```
+
+`harness_id_strategy` (already a slot) drives the branch: `assign` → pre-write meta + `--session-id` + await `session_start`; `derive` → no pre-meta, self-registration, await composer.
+
+---
+
+## Task 1: Widen `harness_launch_argv`; add no-op lifecycle slots to Claude
+
+Keep Phase 1 green while making room for Codex. The widened signature adds `cwd` and `worker_home` (Claude ignores them).
+
+**Files:** `scripts/drivers/claude.sh`, `scripts/csd`, `tests/test-csd-drivers.sh`
+
+- [ ] **Step 1: Update the Claude slot test** — in `tests/test-csd-drivers.sh`, change the two `harness_launch_argv launch SID123 /plug` / `... resume SID123 /plug` calls to the new arity: `harness_launch_argv launch SID123 /cwd /plug /home` and `harness_launch_argv resume SID123 /cwd /plug /home`. (Assertions unchanged — Claude ignores the new args.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash tests/test-csd-drivers.sh`
+Expected: FAIL (extra args shift nothing for Claude, but confirm the call still works; if green already, proceed — the arity is positional and Claude reads only $1,$2,$4).
+
+- [ ] **Step 3: Widen `harness_launch_argv` in `drivers/claude.sh`**
+
+```bash
+# harness_launch_argv <mode> <sid> <cwd> <plugin_dir> <worker_home>
+# Claude uses mode, sid, plugin_dir; ignores cwd + worker_home.
+harness_launch_argv() {
+  local mode="$1" sid="$2" plugin_dir="$4"
+  local bin idflag
+  bin=$(harness_bin)
+  idflag="--session-id"; [ "$mode" = "resume" ] && idflag="--resume"
+  printf '%s\n' \
+    "$bin" "$idflag" "$sid" --plugin-dir "$plugin_dir" \
+    --settings '{"skipDangerousModePermissionPrompt":true}' \
+    --dangerously-skip-permissions \
+    --disallowed-tools AskUserQuestion
+}
+```
+
+- [ ] **Step 4: Add no-op lifecycle slots to `drivers/claude.sh`** (append):
+
+```bash
+# Claude needs no per-worker prep, no post-launch gate dismissal.
+harness_prepare()     { :; }
+harness_post_launch() { :; }
+# Claude readiness == session_start (the spine's existing _await_session_start
+# is invoked directly for assign harnesses; this slot is the derive path's hook).
+harness_await_ready() { :; }
+```
+
+- [ ] **Step 5: Update the two `csd` call sites** to the widened arity
+
+In `cmd_launch`: `harness_launch_argv launch "$session_id" "$working_dir" "$plugin_dir" ""`.
+In `cmd_adopt`: `harness_launch_argv resume "$session_id" "$working_dir" "$plugin_dir" ""`.
+(Both currently pass `launch "$session_id" "$plugin_dir"` / `resume ...`. Add `"$working_dir"` and `""`.)
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `for t in tests/test-*.sh; do bash "$t" >/dev/null 2>&1 && echo "ok $t" || echo "FAIL $t"; done`
+Expected: all green (Claude behavior unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "refactor(csd): widen harness_launch_argv + add no-op lifecycle slots (PRI-2096)"
+```
+
+---
+
+## Task 2: `emit-event-codex` — the self-registering hook
+
+The validated prototype hook. Reads the Codex hook JSON on stdin; self-registers `<sid>.meta`; appends normalized events.
+
+**Files:** `hooks/emit-event-codex`, `tests/test-emit-event-codex.sh`
+
+- [ ] **Step 1: Write the failing test** — `tests/test-emit-event-codex.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/emit-event-codex"
+PASS=0; FAIL=0
+pass(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail(){ echo "  FAIL: $1 - $2"; FAIL=$((FAIL+1)); }
+WD=$(mktemp -d)
+SID="019e0000-0000-7000-8000-000000000001"
+# SessionStart self-registers the meta from the payload.
+printf '%s' "{\"session_id\":\"$SID\",\"transcript_path\":\"/r/$SID.jsonl\",\"cwd\":\"/w\",\"hook_event_name\":\"SessionStart\"}" \
+  | "$HOOK" my-worker /w "$WD"
+[ -f "$WD/$SID.meta" ] && pass "meta self-registered" || fail "meta" "missing"
+[ "$(jq -r '.harness' "$WD/$SID.meta")" = "codex" ] && pass "harness=codex" || fail "harness" "wrong"
+[ "$(jq -r '.tmux_name' "$WD/$SID.meta")" = "my-worker" ] && pass "tmux_name baked" || fail "tmux_name" "wrong"
+[ "$(jq -r '.transcript_path' "$WD/$SID.meta")" = "/r/$SID.jsonl" ] && pass "transcript_path captured" || fail "tp" "wrong"
+[ "$(tail -1 "$WD/$SID.events.jsonl" | jq -r '.event')" = "session_start" ] && pass "session_start event" || fail "event" "wrong"
+# PreToolUse carries the tool name.
+printf '%s' "{\"session_id\":\"$SID\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\"}" | "$HOOK" my-worker /w "$WD"
+[ "$(tail -1 "$WD/$SID.events.jsonl" | jq -r '.tool')" = "Bash" ] && pass "pre_tool_use tool" || fail "tool" "wrong"
+# Stop maps to turn-end.
+printf '%s' "{\"session_id\":\"$SID\",\"hook_event_name\":\"Stop\"}" | "$HOOK" my-worker /w "$WD"
+[ "$(tail -1 "$WD/$SID.events.jsonl" | jq -r '.event')" = "stop" ] && pass "stop event" || fail "stop" "wrong"
+# Missing session_id → no-op, exit 0.
+printf '%s' '{"hook_event_name":"Stop"}' | "$HOOK" my-worker /w "$WD" && pass "no-sid no-ops" || fail "no-sid" "nonzero exit"
+rm -rf "$WD"
+echo "emit-event-codex: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]
+```
+
+- [ ] **Step 2: Run to verify it fails** — Run: `bash tests/test-emit-event-codex.sh` → Expected: FAIL (hook missing).
+
+- [ ] **Step 3: Write `hooks/emit-event-codex`** (the validated prototype, hardened)
+
+```bash
+#!/bin/bash
+set -euo pipefail
+# Codex lifecycle hook for csd. Self-registers the worker meta and appends
+# normalized events to <sid>.events.jsonl. Args: <tmux_name> <cwd> <worker_dir>.
+# Codex bakes these into the hook command in the per-worker CODEX_HOME config.toml.
+TN="${1:-}"; CWD="${2:-}"; WD="${3:-}"
+[ -z "$WD" ] && exit 0
+INPUT=""
+IFS= read -t 5 -d '' INPUT || true
+[ -z "$INPUT" ] && exit 0
+printf '%s' "$INPUT" | jq -e . >/dev/null 2>&1 || exit 0
+SID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty')
+[ -z "$SID" ] && exit 0
+EV=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty')
+TP=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty')
+mkdir -p "$WD"
+if [ ! -f "$WD/$SID.meta" ]; then
+  jq -n --arg tn "$TN" --arg sid "$SID" --arg cwd "$CWD" --arg tp "$TP" \
+    '{tmux_name:$tn, session_id:$sid, cwd:$cwd, transcript_path:$tp, harness:"codex"}' \
+    > "$WD/$SID.meta"
+fi
+case "$EV" in
+  SessionStart)     e=session_start ;;
+  UserPromptSubmit) e=user_prompt_submit ;;
+  PreToolUse)       e=pre_tool_use ;;
+  Stop)             e=stop ;;
+  SessionEnd)       e=session_end ;;
+  *)                e=$(echo "$EV" | sed 's/\([A-Z]\)/_\L\1/g; s/^_//') ;;
+esac
+ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+if [ "$e" = pre_tool_use ]; then
+  tool=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""')
+  ti=$(printf '%s' "$INPUT" | jq -c '.tool_input // {}')
+  jq -cn --arg ts "$ts" --arg event "$e" --arg tool "$tool" --argjson ti "$ti" \
+    '{ts:$ts, event:$event, tool:$tool, tool_input:$ti}' >> "$WD/$SID.events.jsonl"
+else
+  jq -cn --arg ts "$ts" --arg event "$e" '{ts:$ts, event:$event}' >> "$WD/$SID.events.jsonl"
+fi
+exit 0
+```
+
+- [ ] **Step 4: Run the test** — Run: `bash tests/test-emit-event-codex.sh` → Expected: PASS (8 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hooks/emit-event-codex tests/test-emit-event-codex.sh
+git commit -m "feat(csd): self-registering emit-event-codex hook (PRI-2096)"
+```
+
+---
+
+## Task 3: `drivers/codex.sh` — manifest + prepare + launch + post-launch slots
+
+**Files:** `scripts/drivers/codex.sh`, `tests/test-csd-codex.sh`
+
+- [ ] **Step 1: Write failing driver unit tests** — `tests/test-csd-codex.sh` (driver section)
+
+```bash
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCR="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts"
+PASS=0; FAIL=0
+pass(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail(){ echo "  FAIL: $1 - $2"; FAIL=$((FAIL+1)); }
+probe(){ ( source "$SCR/_lib.sh"; _load_driver codex; "$@" ); }
+[ "$(probe harness_id)" = "codex" ] && pass "id=codex" || fail "id" "wrong"
+[ "$(probe harness_control_plane)" = "hooks" ] && pass "control_plane=hooks" || fail "cp" "wrong"
+[ "$(probe harness_id_strategy)" = "derive" ] && pass "id_strategy=derive" || fail "ids" "wrong"
+[ "$(probe harness_quit_keys)" = "/quit" ] && pass "quit=/quit" || fail "quit" "wrong"
+[ "$(probe harness_bin)" = "codex" ] && pass "bin=codex" || fail "bin" "wrong"
+# prepare writes a CODEX_HOME config.toml with hooks + project trust
+HOME_DIR=$(mktemp -d); CWD=$(mktemp -d)
+( source "$SCR/_lib.sh"; _load_driver codex; CSD_PLUGIN_DIR=/plug harness_prepare wkr "$CWD" "$HOME_DIR" )
+[ -f "$HOME_DIR/config.toml" ] && pass "config.toml written" || fail "config" "missing"
+grep -q 'emit-event-codex wkr' "$HOME_DIR/config.toml" && pass "hook bakes tmux_name" || fail "hook arg" "missing"
+grep -q "\\[\\[hooks.SessionStart\\]\\]" "$HOME_DIR/config.toml" && pass "SessionStart hook" || fail "sshook" "missing"
+grep -q "trust_level" "$HOME_DIR/config.toml" && pass "project trust" || fail "trust" "missing"
+# launch argv: no --session-id; has -C <cwd> + bypass flags
+av=$( ( source "$SCR/_lib.sh"; _load_driver codex; harness_launch_argv launch "" "$CWD" /plug "$HOME_DIR" ) )
+echo "$av" | grep -qx -- "--dangerously-bypass-approvals-and-sandbox" && pass "yolo flag" || fail "yolo" "missing"
+echo "$av" | grep -qx -- "--session-id" && fail "no sid" "should be absent" || pass "no --session-id"
+echo "$av" | grep -qx -- "-C" && pass "-C cwd" || fail "-C" "missing"
+rm -rf "$HOME_DIR" "$CWD"
+echo "codex-driver: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]
+```
+
+- [ ] **Step 2: Run to verify it fails** — Run: `bash tests/test-csd-codex.sh` → Expected: FAIL (no codex driver).
+
+- [ ] **Step 3: Write `drivers/codex.sh`**
+
+```bash
+#!/bin/bash
+# Codex (OpenAI) harness driver for csd. Sourced, not executed. derive-id +
+# hook control plane. See spec Appendix B.
+
+harness_id()            { echo "codex"; }
+harness_bin()           { echo "${CSD_CODEX_BIN:-codex}"; }
+harness_control_plane() { echo "hooks"; }
+harness_id_strategy()   { echo "derive"; }
+harness_quit_keys()     { echo "/quit"; }
+
+# Per-worker config: CODEX_HOME holds a config.toml registering the
+# self-registering hook on each lifecycle event, plus project trust. Auth is
+# staged so the worker authenticates as the operator (subscription).
+# Reads CSD_PLUGIN_DIR (set by the spine) to locate emit-event-codex.
+harness_prepare() {
+  local tmux_name="$1" cwd="$2" home="$3"
+  local hook="${CSD_PLUGIN_DIR}/hooks/emit-event-codex"
+  local model="${CSD_CODEX_MODEL:-gpt-5.5}"
+  mkdir -p "$home"
+  [ -f "$HOME/.codex/auth.json" ] && cp "$HOME/.codex/auth.json" "$home/" 2>/dev/null || true
+  {
+    echo "model = \"$model\""
+    echo "model_reasoning_effort = \"low\""
+    echo "[projects.\"$cwd\"]"
+    echo "trust_level = \"trusted\""
+    local ev
+    for ev in SessionStart UserPromptSubmit PreToolUse PostToolUse Stop SessionEnd; do
+      echo "[[hooks.$ev]]"
+      case "$ev" in PreToolUse|PostToolUse) echo "matcher = \".*\"" ;; esac
+      echo "[[hooks.$ev.hooks]]"
+      echo "type = \"command\""
+      echo "command = \"$hook $tmux_name $cwd $_CSD_WORKER_DIR\""
+    done
+  } > "$home/config.toml"
+}
+
+# harness_launch_argv <mode> <sid> <cwd> <plugin_dir> <worker_home>
+# Codex ignores sid (derive) + plugin_dir (hooks via CODEX_HOME) + worker_home
+# (passed as env by harness_env_args). Interactive; -C sets the workdir.
+harness_launch_argv() {
+  local cwd="$3"
+  printf '%s\n' \
+    "$(harness_bin)" \
+    --dangerously-bypass-approvals-and-sandbox \
+    --dangerously-bypass-hook-trust \
+    -C "$cwd"
+}
+
+# CODEX_HOME points codex at the per-worker config/auth/sessions dir.
+# The spine sets _CSD_CURRENT_WORKER_HOME before calling this.
+harness_env_args() {
+  WORKER_ENV_ARGS=(-e "CODEX_HOME=${_CSD_CURRENT_WORKER_HOME}")
+}
+
+# Dismiss the "Hooks need review" trust gate (bypass flag does NOT auto-skip it).
+harness_post_launch() {
+  local tmux_name="$1" deadline=$((SECONDS + 8)) pane
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    pane=$(tmux capture-pane -t "$tmux_name" -p 2>/dev/null || true)
+    if echo "$pane" | grep -qiE 'hooks need review|trust all|review'; then
+      tmux send-keys -t "$tmux_name" -l '2'; sleep 0.3
+      tmux send-keys -t "$tmux_name" Enter
+      return 0
+    fi
+    sleep 0.25
+  done
+}
+
+# derive readiness: no session_start at boot (it fires at first prompt). Wait
+# for the composer to appear, else a short settle.
+harness_await_ready() {
+  local tmux_name="$1" deadline=$((SECONDS + 20)) pane
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    pane=$(tmux capture-pane -t "$tmux_name" -p 2>/dev/null || true)
+    echo "$pane" | grep -q '›' && return 0   # codex composer prompt glyph
+    sleep 0.5
+  done
+  return 0   # best-effort; the first send re-confirms via self-registration
+}
+
+# transcript path is recorded by the self-registering hook; read it from meta.
+harness_transcript_path() {
+  local sid="$1"
+  jq -r '.transcript_path // empty' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null
+}
+```
+
+(`harness_parse_turn`/`harness_count_text`/`harness_last_text` for codex are added in Task 5.)
+
+- [ ] **Step 4: Run the driver test** — Run: `bash tests/test-csd-codex.sh` → Expected: the driver-section assertions PASS (the integration test is added in Task 6 and will fail until then; split the file or guard it — see Task 6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/driving-claude-code-sessions/scripts/drivers/codex.sh tests/test-csd-codex.sh
+git commit -m "feat(csd): codex driver manifest + prepare/launch/post-launch slots (PRI-2096)"
+```
+
+---
+
+## Task 4: Spine — `derive` launch branch in `cmd_launch`
+
+Branch `cmd_launch` on `harness_id_strategy`. `assign` keeps Phase 1 exactly; `derive` runs prepare → launch → post_launch → await_ready, with **no** pre-written meta and **no** `_await_session_start`.
+
+**Files:** `scripts/csd`
+
+- [ ] **Step 1: Export plugin dir + set per-worker home for drivers**
+
+Near the top of `cmd_launch` (after `plugin_dir` is resolved), add:
+```bash
+  export CSD_PLUGIN_DIR="$plugin_dir"
+  local worker_home="$_CSD_WORKER_DIR/homes/$tmux_name"
+  _CSD_CURRENT_WORKER_HOME="$worker_home"
+```
+
+- [ ] **Step 2: Gate the assign-only pre-meta + id generation**
+
+Wrap the `session_id=$(uuidgen…)` + meta `jq -n … > <sid>.meta` block in:
+```bash
+  local session_id=""
+  if [ "$(harness_id_strategy)" = "assign" ]; then
+    session_id=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    # ... existing meta pre-write keyed by $session_id ...
+  fi
+```
+
+- [ ] **Step 3: Call `harness_prepare` before launch, branch the readiness**
+
+Replace the launch sequence so it reads:
+```bash
+  harness_prepare "$tmux_name" "$working_dir" "$worker_home"
+  local launch_argv=()
+  while IFS= read -r _tok; do launch_argv+=("$_tok"); done \
+    < <(harness_launch_argv launch "$session_id" "$working_dir" "$plugin_dir" "$worker_home")
+  local WORKER_ENV_ARGS=()
+  harness_env_args
+  tmux new-session -d -s "$tmux_name" -c "$working_dir" \
+    "${WORKER_ENV_ARGS[@]}" "${launch_argv[@]}" \
+    "${extra_args[@]+"${extra_args[@]}"}"
+  harness_post_launch "$tmux_name"
+  if [ "$(harness_id_strategy)" = "assign" ]; then
+    _await_session_start "$tmux_name" "$session_id" || return 1
+  else
+    harness_await_ready "$tmux_name" ""
+  fi
+```
+
+- [ ] **Step 4: Fix the events-path panel line for derive**
+
+The "Worker launched" stderr panel references `$_CSD_WORKER_DIR/${session_id}.events.jsonl`. For derive, `session_id` is empty at this point. Make the events line conditional:
+```bash
+  if [ -n "$session_id" ]; then
+    echo "  events:     $_CSD_WORKER_DIR/${session_id}.events.jsonl"
+  else
+    echo "  events:     (registered on first prompt; csd list will show it)"
+  fi
+```
+
+- [ ] **Step 5: Smoke with the fake (deferred)** — the real check is Task 6's integration test. For now:
+
+Run: `bash -n skills/driving-claude-code-sessions/scripts/csd && echo ok`
+Run: `for t in tests/test-*.sh; do bash "$t" >/dev/null 2>&1 || echo "FAIL $t"; done`
+Expected: parses; all Phase-1 (assign/Claude) tests still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(csd): derive-id launch branch in cmd_launch (PRI-2096)"
+```
+
+---
+
+## Task 5: Codex turn parser + pre-registration tolerance in send/converse
+
+**Files:** `scripts/drivers/codex.sh`, `scripts/csd`, `scripts/_lib.sh`
+
+- [ ] **Step 1: Add `_worker_tmux_name` to `_lib.sh`** (resolve the tmux session without a registered sid)
+
+```bash
+# Print the tmux session name for <worker>. Works before self-registration:
+# falls back to <worker> itself when it names a live tmux session (the shim sets
+# --worker to the tmux_name).
+_worker_tmux_name() {
+  local worker="$1" sid meta tn
+  sid=$(resolve_session "$worker" 2>/dev/null) || sid=""
+  if [ -n "$sid" ] && [ -f "$_CSD_WORKER_DIR/${sid}.meta" ]; then
+    tn=$(jq -r '.tmux_name' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null)
+    [ -n "$tn" ] && [ "$tn" != "null" ] && { echo "$tn"; return 0; }
+  fi
+  if tmux has-session -t "$worker" 2>/dev/null; then echo "$worker"; return 0; fi
+  echo "$worker"
+}
+```
+
+- [ ] **Step 2: `cmd_send` — use `_worker_tmux_name`; relax submit-confirm for derive**
+
+In `cmd_send`, replace `tmux_name=$(jq -r '.tmux_name' "$_CSD_WORKER_DIR/${sid}.meta")` (which needs a sid) with `tmux_name=$(_worker_tmux_name "$WORKER")`, and the `before_line`/`_prompt_submitted_since` logic: for derive workers with no sid yet, poll for self-registration first, then confirm via the registered events file. Concretely, after sending the paste+Enter, replace the confirm loop with:
+```bash
+  # Discover the (possibly just-registered) session + events file.
+  local sid events_file
+  sid=$(resolve_session "$WORKER" 2>/dev/null) || sid=""
+  if [ -z "$sid" ]; then
+    # derive: wait up to submit_timeout for the hook to self-register.
+    local d=$((SECONDS + submit_timeout))
+    while [ "$SECONDS" -lt "$d" ] && [ -z "$sid" ]; do sleep 0.25; sid=$(resolve_session "$WORKER" 2>/dev/null) || sid=""; done
+  fi
+  [ -n "$sid" ] && events_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
+```
+then key the existing `_prompt_submitted_since`/retry on `$events_file` (skip the retry gracefully if `$sid` is still empty — self-registration is the confirmation). Preserve the assign path exactly (sid is known up front).
+
+- [ ] **Step 3: `cmd_converse` — resolve sid AFTER the first send for derive**
+
+`cmd_converse` currently resolves `sid`/`cwd`/`log_file` before sending. For derive, move the sid/log_file resolution to AFTER `cmd_send` returns (when self-registration has happened). Structure:
+```bash
+  if [ "$(harness_id_strategy)" = "assign" ]; then
+    sid=$(resolve_session "$WORKER"); cwd=$(jq -r .cwd "$_CSD_WORKER_DIR/$sid.meta"); log_file=$(harness_transcript_path "$sid" "$cwd"); before_count=$(harness_count_text "$log_file")
+  fi
+  cmd_send "$prompt"
+  if [ "$(harness_id_strategy)" = "derive" ]; then
+    sid=$(resolve_session "$WORKER"); log_file=$(harness_transcript_path "$sid")  # codex reads tp from meta
+    before_count=0
+  fi
+  # ... existing wait_for_turn on <sid>.events.jsonl, then read response ...
+```
+(`harness_transcript_path` for codex takes just `<sid>` — it reads `transcript_path` from meta. Claude's takes `<sid> <cwd>`. Both are called with the args each needs; the spine passes `"$sid" "$cwd"` and codex ignores `$2`.)
+
+- [ ] **Step 4: Add the codex turn parser to `drivers/codex.sh`**
+
+```bash
+# Render the last turn of a codex rollout as markdown.
+harness_parse_turn() {
+  local rollout="$1" full=false
+  [ "${2:-}" = "--full" ] && full=true
+  [ -f "$rollout" ] || { echo "No rollout at $rollout" >&2; return 1; }
+  # Last user message line onward.
+  local start
+  start=$(grep -n '"type":"response_item"' "$rollout" | grep '"role":"user"' | tail -1 | cut -d: -f1)
+  [ -z "$start" ] && start=1
+  tail -n +"$start" "$rollout" | jq -r '
+    select(.type=="response_item") | .payload as $p |
+    if   $p.type=="message" then "**["+$p.role+"]** " + ([$p.content[]?.text // $p.content[]?.output_text // ""] | join(""))+"\n"
+    elif $p.type=="reasoning" then "> **Thinking:** " + (($p.summary // []) | map(.text // .) | join(" "))+"\n"
+    elif $p.type=="function_call" then "**Tool: "+$p.name+"**\n```\n"+$p.arguments+"\n```\n"
+    elif $p.type=="function_call_output" then "**Result:**\n```\n"+($p.output|tostring)+"\n```\n"
+    else empty end' 2>/dev/null
+}
+harness_count_text() {
+  local rollout="$1"; [ -f "$rollout" ] || { echo 0; return; }
+  grep -c '"type":"event_msg".*"agent_message"' "$rollout" 2>/dev/null || echo 0
+}
+harness_last_text() {
+  local rollout="$1"; [ -f "$rollout" ] || return 0
+  grep '"type":"event_msg"' "$rollout" | jq -rs 'map(select(.payload.type=="agent_message")) | last | .payload.message // ""' 2>/dev/null
+}
+```
+
+- [ ] **Step 5: Verify Phase-1 suite still green** (assign path untouched)
+
+Run: `for t in tests/test-*.sh; do bash "$t" >/dev/null 2>&1 || echo "FAIL $t"; done`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(csd): codex turn parser + pre-registration tolerance (PRI-2096)"
+```
+
+---
+
+## Task 6: Fake-codex integration test (launch → converse → read-turn)
+
+A fake `codex` lets us test the whole derive flow without API calls. The fake reads its `CODEX_HOME/config.toml`, fires the SessionStart/UserPromptSubmit/PreToolUse/Stop hooks with synthetic payloads (so `emit-event-codex` self-registers), writes a minimal rollout at a path it reports via `transcript_path`, and `exec sleep`s to stay alive.
+
+**Files:** `tests/fixtures/fake-codex`, `tests/test-csd-codex.sh`
+
+- [ ] **Step 1: Write `tests/fixtures/fake-codex`**
+
+```bash
+#!/bin/bash
+# Fake codex for tests. Parses -C <cwd>; reads CODEX_HOME/config.toml to find the
+# emit-event-codex hook command; mints a uuid; fires hooks with synthetic
+# payloads; writes a minimal rollout; stays alive.
+cwd="."; while [ $# -gt 0 ]; do case "$1" in -C) cwd="$2"; shift 2;; *) shift;; esac; done
+SID="019efake-0000-7000-8000-$(printf '%012d' $$)"
+DAY=$(date -u +%Y/%m/%d)
+ROLL="$CODEX_HOME/sessions/$DAY/rollout-$(date -u +%Y-%m-%dT%H-%M-%S)-$SID.jsonl"
+mkdir -p "$(dirname "$ROLL")"
+printf '{"type":"session_meta","payload":{"id":"%s","cwd":"%s"}}\n' "$SID" "$cwd" > "$ROLL"
+# Extract the hook command (first emit-event-codex line) from config.toml.
+HOOKCMD=$(grep -m1 'emit-event-codex' "$CODEX_HOME/config.toml" | sed 's/^command = "//; s/"$//')
+fire(){ printf '{"session_id":"%s","transcript_path":"%s","cwd":"%s","hook_event_name":"%s"%s}' \
+  "$SID" "$ROLL" "$cwd" "$1" "${2:-}" | $HOOKCMD; }
+# A real codex fires hooks at first prompt; the fake fires them at boot for the
+# test's first turn. (The test sends a prompt; we simulate the resulting turn.)
+fire SessionStart
+fire UserPromptSubmit ',"prompt":"hi"'
+fire PreToolUse ',"tool_name":"Bash"'
+printf '{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"FAKE_DONE"}]}}\n' >> "$ROLL"
+printf '{"type":"event_msg","payload":{"type":"agent_message","message":"FAKE_DONE"}}\n' >> "$ROLL"
+fire Stop
+exec sleep 60
+```
+
+- [ ] **Step 2: Append the integration test to `tests/test-csd-codex.sh`**
+
+```bash
+# --- integration: fake-codex launch -> converse -> read-turn ---
+FAKE="$SCRIPT_DIR/fixtures/fake-codex"; chmod +x "$FAKE"
+IHOME=$(mktemp -d); mkdir -p "$IHOME/.codex"; touch "$IHOME/.codex/.claude-session-driver-consent"
+ITN="test-codex-$$"; IWD=$(mktemp -d)
+SHIM=$(CSD_CODEX_BIN="$FAKE" HOME="$IHOME" bash "$SCR/csd" launch --harness codex "$ITN" "$IWD" 2>/dev/null) || true
+# The fake fires hooks at boot, so by now the worker self-registered.
+sleep 1
+OUT=$(CSD_CODEX_BIN="$FAKE" HOME="$IHOME" bash "$SCR/csd" --worker "$ITN" read-turn 2>/dev/null || true)
+echo "$OUT" | grep -q "FAKE_DONE" && pass "codex read-turn renders the turn" || fail "read-turn" "got: $OUT"
+ST=$(CSD_CODEX_BIN="$FAKE" HOME="$IHOME" bash "$SCR/csd" --worker "$ITN" status 2>/dev/null || true)
+[ "$ST" = "idle" ] && pass "codex status idle after stop" || fail "status" "got $ST"
+# cleanup
+CSD_CODEX_BIN="$FAKE" HOME="$IHOME" bash "$SCR/csd" --worker "$ITN" stop >/dev/null 2>&1 || true
+tmux kill-session -t "$ITN" 2>/dev/null || true
+rm -rf "$IHOME" "$IWD"
+```
+
+(Note: the fake fires hooks at boot rather than on a real prompt, so the integration test exercises self-registration + events + read-turn + status without needing `send` to drive a real model. A separate **real-codex** smoke is Task 7.)
+
+- [ ] **Step 3: Run the codex test** — Run: `bash tests/test-csd-codex.sh` → Expected: PASS (driver + integration).
+
+- [ ] **Step 4: Full suite** — Run: `for t in tests/test-*.sh; do bash "$t" >/dev/null 2>&1 && echo "ok $t" || echo "FAIL $t"; done` → Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/fake-codex tests/test-csd-codex.sh
+git commit -m "test(csd): fake-codex integration test for derive-id flow (PRI-2096)"
+```
+
+---
+
+## Task 7: Real-codex smoke test (gated, manual)
+
+A scripted real-codex run mirroring the validated prototype, runnable on demand (it costs a subscription turn). Not part of the default suite.
+
+**Files:** `tests/smoke-codex-real.sh`
+
+- [ ] **Step 1: Write `tests/smoke-codex-real.sh`** — launches a real codex worker via `csd launch --harness codex`, `converse`s a trivial tool-using prompt, asserts `read-turn` shows the result, then `stop`s. Guard with `[ -n "${CSD_RUN_REAL_CODEX:-}" ] || { echo "set CSD_RUN_REAL_CODEX=1 to run"; exit 0; }`.
+
+- [ ] **Step 2: Run it once** — Run: `CSD_RUN_REAL_CODEX=1 bash tests/smoke-codex-real.sh` → Expected: a real Codex worker drives a turn end-to-end and `read-turn` shows the model's reply. Record the result in the PR/ticket.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/smoke-codex-real.sh
+git commit -m "test(csd): gated real-codex end-to-end smoke (PRI-2096)"
+```
+
+---
+
+## Final verification
+
+- [ ] Full suite green: `for t in tests/test-*.sh; do echo "== $t =="; bash "$t" || break; done` — all `0 failed`.
+- [ ] Real-codex smoke passed once (Task 7).
+- [ ] `csd launch --harness codex <name> <cwd>` → `converse` → `read-turn` → `stop` works against real codex.
+- [ ] Claude unchanged: every Phase-1 test still green (assign path untouched).
+
+## Self-Review
+
+**Spec coverage (Appendix B):** derive-id self-registration → Tasks 2,4; per-worker CODEX_HOME config + auth + trust → Task 3; trust-gate `2` dismissal → Task 3 (`harness_post_launch`); readiness-not-session_start → Tasks 3,4; pre-registration window tolerance → Task 5; codex rollout parser → Task 5; fake + real validation → Tasks 6,7.
+
+**Placeholder scan:** none — hook + driver + fake are complete; the `cmd_launch`/`cmd_send`/`cmd_converse` edits show the exact branch code.
+
+**Type/name consistency:** new slots `harness_prepare`/`harness_post_launch`/`harness_await_ready`, widened `harness_launch_argv` arity, `_worker_tmux_name`, `_CSD_CURRENT_WORKER_HOME`, `CSD_PLUGIN_DIR`, `CSD_CODEX_BIN`/`CSD_CODEX_MODEL` used consistently across tasks.
+
+**Risks for the reviewer (Riker):**
+- `cmd_converse`/`cmd_send` carry the most spine risk (the assign/derive branch + the post-send sid discovery). Verify the assign path is byte-for-byte behavior-preserving.
+- `harness_env_args` for codex relies on `_CSD_CURRENT_WORKER_HOME` being set before launch — confirm scope/ordering in `cmd_launch`.
+- The fake fires hooks at boot (not on a prompt); the real flow fires at first prompt. The integration test therefore can't exercise the `send`-triggered registration timing — Task 7 (real) covers that. Flag if a fake that fires on a sent prompt is worth the extra complexity.
+- Codex `harness_env_args` REPLACES the Claude provider-env pinning for codex workers (different isolation lever) — confirm that's intended (it is: CODEX_HOME is codex's isolation, not the CLAUDE_CODE_* vars).
+- `harness_await_ready` greps the pane for `›` — brittle if the codex TUI glyph differs by version; it's best-effort (the first send re-confirms), but note it.

--- a/docs/superpowers/plans/2026-06-06-csd-multiharness-phase3-pi.md
+++ b/docs/superpowers/plans/2026-06-06-csd-multiharness-phase3-pi.md
@@ -1,0 +1,429 @@
+# CSD Multi-Harness — Phase 3: Pi Driver + Poller Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drive **Pi** workers through `csd` — same contract as Claude/Codex — reusing the Phase-2 derive-id spine. Pi has **no hooks**, so a `csd poll` background tailer is the control-plane *producer*: it watches Pi's session JSONL, self-registers `<sid>.meta`, and synthesizes the same `<sid>.events.jsonl` the spine already consumes.
+
+**Architecture:** `derive` id strategy (same as Codex). The only structural difference from Codex: `harness_post_launch` starts the poller (a `csd poll` process in a second tmux window of the worker's session) instead of dismissing a trust gate. Everything else — sidecar bootstrap, dispatcher fallback, `cmd_send`/`cmd_converse` pre-registration tolerance, `_worker_tmux_name`, self-registered meta — is **reused unchanged**. **Validated end-to-end against real pi 0.75.3** (see Design notes).
+
+**Tech Stack:** Bash 3.2 (no mapfile/assoc arrays), `jq`, `tmux`, `pi` CLI. Pi mocked in tests via `CSD_PI_BIN` → a fake that writes a session JSONL (no API).
+
+**Spec:** `docs/superpowers/specs/2026-06-05-csd-multiharness-design.md` (Appendix A = Pi flush probe; Appendix B = derive-id flow).
+
+**Depends on:** Phase 1 (slots) + Phase 2 (derive-id spine). **Out of scope:** changes to the assign (Claude) or Codex paths.
+
+---
+
+## Design notes (validated against real pi 0.75.3)
+
+- **Launch:** interactive `pi --session-dir <wsd> --model <route> --no-extensions --no-skills` in tmux, with `PI_CODING_AGENT_DIR=<staged-auth>` + `PI_CODING_AGENT_SESSION_DIR=<wsd>`. Tools run **unattended** (no permission gate). **Quit is `/quit`.**
+- **Session file:** `<wsd>/<ISO-ts>_<uuidv7>.jsonl` (flat under `--session-dir`). Line 1: `{"type":"session","version":3,"id":"<uuid>","cwd":"<abs>"}`.
+- **Record → event map (proven by the prototype):**
+  | session record | event |
+  |---|---|
+  | `{"type":"session", id, cwd}` (line 1) | self-register meta + `session_start` |
+  | `message` role=`user` | `user_prompt_submit` |
+  | `message` role=`assistant` `stopReason:"toolUse"` (content `toolCall`) | `pre_tool_use` |
+  | `message` role=`toolResult` | `post_tool_use` |
+  | `message` role=`assistant` `stopReason:"stop"` (or `error`) | `stop` |
+  | tmux pane gone | `session_end` |
+- **Response:** last `assistant` `message` text content (`content[].type=="text"`).
+- **Model/auth:** `--model openai-codex/gpt-5.5` (or `CSD_PI_MODEL`), authenticating from a staged `~/.pi/agent` (`auth.json`).
+
+---
+
+## File Structure
+
+- **Create** `scripts/drivers/pi.sh` — Pi driver slots + `harness_poll` (the tailer body).
+- **Modify** `scripts/csd` — add the internal `poll` subcommand (runs `harness_poll`); no other spine changes (derive flow reused).
+- **Create** `tests/fixtures/fake-pi` — writes a Pi session JSONL incrementally (no API).
+- **Create** `tests/test-csd-pi.sh` — driver units + poller unit + fake-pi integration (incl. multi-turn).
+- **Create** `tests/smoke-pi-real.sh` — gated real-pi multi-turn smoke.
+
+### Slot additions
+
+```
+harness_poll <session_dir> <worker_dir> <tmux_name>   # the tailer loop (pi only)
+```
+`harness_control_plane` returns `"poll"`; `harness_post_launch` starts the poller.
+
+---
+
+## Task 1: `drivers/pi.sh` manifest + `harness_poll` (the tailer)
+
+**Files:** `scripts/drivers/pi.sh`, `tests/test-csd-pi.sh`
+
+- [ ] **Step 1: Write failing manifest + poller-unit tests** — `tests/test-csd-pi.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCR="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts"
+PASS=0; FAIL=0
+pass(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail(){ echo "  FAIL: $1 - $2"; FAIL=$((FAIL+1)); }
+probe(){ ( source "$SCR/_lib.sh"; _load_driver pi; "$@" ); }
+
+[ "$(probe harness_id)" = "pi" ] && pass "id=pi" || fail "id" "wrong"
+[ "$(probe harness_control_plane)" = "poll" ] && pass "control_plane=poll" || fail "cp" "wrong"
+[ "$(probe harness_id_strategy)" = "derive" ] && pass "id_strategy=derive" || fail "ids" "wrong"
+[ "$(probe harness_quit_keys)" = "/quit" ] && pass "quit=/quit" || fail "quit" "wrong"
+
+# harness_poll self-registers the meta + synthesizes events from a session file.
+SD=$(mktemp -d); WDIR=$(mktemp -d)
+SID="019e0000-0000-7000-8000-0000000000aa"
+SF="$SD/2026-01-01T00-00-00-000Z_${SID}.jsonl"
+{
+  printf '{"type":"session","version":3,"id":"%s","cwd":"/w"}\n' "$SID"
+  printf '{"type":"message","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}\n'
+  printf '{"type":"message","message":{"role":"assistant","stopReason":"toolUse","content":[{"type":"toolCall","name":"bash","arguments":{"command":"echo x"}}]}}\n'
+  printf '{"type":"message","message":{"role":"toolResult","toolName":"bash","content":[{"type":"text","text":"x"}]}}\n'
+  printf '{"type":"message","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"PI_ANSWER"}]}}\n'
+} > "$SF"
+# Run the poller briefly against a NON-existent tmux session so it emits session_end and exits.
+( source "$SCR/_lib.sh"; _load_driver pi; harness_poll "$SD" "$WDIR" "no-such-tmux-$$" ) >/dev/null 2>&1 || true
+M=$(ls "$WDIR"/*.meta 2>/dev/null | head -1)
+[ -n "$M" ] && [ "$(jq -r '.harness' "$M")" = "pi" ] && pass "poller self-registers pi meta" || fail "meta" "missing"
+[ "$(jq -r '.session_id' "$M")" = "$SID" ] && pass "meta has session id from line 1" || fail "sid" "wrong"
+EV="${M%.meta}.events.jsonl"
+ev_seq=$(jq -r '.event' "$EV" | tr '\n' ',')
+echo "$ev_seq" | grep -q 'session_start,user_prompt_submit,pre_tool_use,post_tool_use,stop' && pass "poller synthesizes the event sequence" || fail "events" "got $ev_seq"
+rm -rf "$SD" "$WDIR"
+echo "pi-driver: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]
+```
+
+- [ ] **Step 2: Run to verify it fails** — `bash tests/test-csd-pi.sh` → FAIL (no pi driver).
+
+- [ ] **Step 3: Write `drivers/pi.sh`** (manifest + `harness_poll`, validated logic)
+
+```bash
+#!/bin/bash
+# Pi (Earendil) harness driver for csd. Sourced, not executed. derive-id, but the
+# control plane is a POLLER (Pi has no hooks): csd poll tails the session JSONL,
+# self-registers the meta, and synthesizes the same events.jsonl. Validated
+# against pi 0.75.3.
+
+harness_id()            { echo "pi"; }
+harness_bin()           { echo "${CSD_PI_BIN:-pi}"; }
+harness_control_plane() { echo "poll"; }
+harness_id_strategy()   { echo "derive"; }
+harness_quit_keys()     { echo "/quit"; }
+
+# harness_poll <session_dir> <worker_dir> <tmux_name>
+# Tail the newest session JSONL in <session_dir>; self-register <sid>.meta from
+# line 1; map records -> normalized events; exit (emitting session_end) when the
+# worker's tmux session is gone. Runs in a second tmux window of the worker.
+harness_poll() {
+  local sd="$1" wd="$2" tn="$3" f="" i
+  for i in $(seq 1 120); do
+    f=$(find "$sd" -name '*.jsonl' -type f 2>/dev/null | head -1)
+    [ -n "$f" ] && break
+    tmux has-session -t "$tn" 2>/dev/null || return 0
+    sleep 0.5
+  done
+  [ -z "$f" ] && return 0
+  local sid cwd
+  sid=$(head -1 "$f" | jq -r '.id // empty' 2>/dev/null) || sid=""
+  cwd=$(head -1 "$f" | jq -r '.cwd // empty' 2>/dev/null) || cwd=""
+  [ -z "$sid" ] && return 0
+  if [ ! -f "$wd/$sid.meta" ]; then
+    jq -n --arg tn "$tn" --arg sid "$sid" --arg cwd "$cwd" --arg tp "$f" \
+      '{tmux_name:$tn, session_id:$sid, cwd:$cwd, transcript_path:$tp, harness:"pi"}' \
+      > "$wd/$sid.meta"
+  fi
+  local ev="$wd/$sid.events.jsonl"
+  _pi_emit(){ jq -cn --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --arg e "$1" '{ts:$ts, event:$e}' >> "$ev"; }
+  _pi_emit session_start
+  local prev=1 n line typ role stop
+  while true; do
+    n=$(wc -l < "$f" | tr -d ' ')
+    if [ "$n" -gt "$prev" ]; then
+      while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        typ=$(printf '%s' "$line" | jq -r '.type // empty' 2>/dev/null) || typ=""
+        role=$(printf '%s' "$line" | jq -r '.message.role // empty' 2>/dev/null) || role=""
+        stop=$(printf '%s' "$line" | jq -r '.message.stopReason // empty' 2>/dev/null) || stop=""
+        case "$typ:$role:$stop" in
+          message:user:*)            _pi_emit user_prompt_submit ;;
+          message:assistant:toolUse) _pi_emit pre_tool_use ;;
+          message:toolResult:*)      _pi_emit post_tool_use ;;
+          message:assistant:stop)    _pi_emit stop ;;
+          message:assistant:error)   _pi_emit stop ;;
+        esac
+      done < <(tail -n +"$((prev+1))" "$f")
+      prev=$n
+    fi
+    tmux has-session -t "$tn" 2>/dev/null || { _pi_emit session_end; break; }
+    sleep 0.3
+  done
+}
+```
+
+- [ ] **Step 4: Run the test** — `bash tests/test-csd-pi.sh` → PASS (the poller test runs against a missing tmux session so it self-registers, synthesizes, emits session_end, and exits).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/driving-claude-code-sessions/scripts/drivers/pi.sh tests/test-csd-pi.sh
+git commit -m "feat(csd): pi driver manifest + harness_poll tailer (PRI-2096)"
+```
+
+---
+
+## Task 2: Pi prepare / launch / env / post-launch (start the poller) / parser slots
+
+**Files:** `scripts/drivers/pi.sh`, `tests/test-csd-pi.sh`
+
+- [ ] **Step 1: Add failing slot assertions** — append to `tests/test-csd-pi.sh` (before the final echo):
+
+```bash
+# prepare stages auth + creates the session dir; launch argv has --session-dir, no --session-id
+HOME_DIR=$(mktemp -d); CWD=$(mktemp -d)
+( source "$SCR/_lib.sh"; _load_driver pi; CSD_PLUGIN_DIR=/plug HOME=/nonexistent harness_prepare wkr "$CWD" "$HOME_DIR" )
+[ -d "$HOME_DIR/sessions" ] && pass "pi session dir created" || fail "session dir" "missing"
+av=$( ( source "$SCR/_lib.sh"; _load_driver pi; harness_launch_argv launch "" "$CWD" /plug "$HOME_DIR" ) )
+echo "$av" | grep -qx -- "--session-dir" && pass "pi --session-dir" || fail "--session-dir" "missing"
+echo "$av" | grep -qx -- "--session-id" && fail "no sid" "should be absent" || pass "no --session-id"
+ea=$( ( source "$SCR/_lib.sh"; _load_driver pi; WORKER_ENV_ARGS=(); harness_env_args; printf '%s\n' "${WORKER_ENV_ARGS[@]}" ) )
+echo "$ea" | grep -q '^PI_CODING_AGENT_SESSION_DIR=' && pass "pi env session dir" || fail "env" "missing"
+# parse_turn renders a pi session
+SF2=$(mktemp)
+printf '%s\n' \
+  '{"type":"session","version":3,"id":"x","cwd":"/w"}' \
+  '{"type":"message","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}' \
+  '{"type":"message","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"PI_HELLO"}]}}' > "$SF2"
+out=$( ( source "$SCR/_lib.sh"; _load_driver pi; harness_parse_turn "$SF2" ) )
+echo "$out" | grep -q "PI_HELLO" && pass "pi parse_turn renders text" || fail "parse" "got: $out"
+lt=$( ( source "$SCR/_lib.sh"; _load_driver pi; harness_last_text "$SF2" ) )
+[ "$lt" = "PI_HELLO" ] && pass "pi last_text" || fail "last_text" "got: $lt"
+rm -rf "$HOME_DIR" "$CWD" "$SF2"
+```
+
+- [ ] **Step 2: Run to verify it fails** — `bash tests/test-csd-pi.sh` → FAIL.
+
+- [ ] **Step 3: Add the remaining slots to `drivers/pi.sh`** (append):
+
+```bash
+# Stage Pi auth into a per-worker config dir + create the session dir. The spine
+# sets _CSD_CURRENT_WORKER_HOME to <worker_dir>/homes/<tmux_name>; we use it as
+# PI_CODING_AGENT_DIR and put sessions under it.
+harness_prepare() {
+  local tmux_name="$1" cwd="$2" home="$3"
+  mkdir -p "$home/sessions"
+  if [ -d "$HOME/.pi/agent" ]; then
+    cp "$HOME/.pi/agent/auth.json" "$home/" 2>/dev/null || true
+    cp "$HOME/.pi/agent/settings.json" "$home/" 2>/dev/null || true
+  fi
+}
+
+# harness_launch_argv <mode> <sid> <cwd> <plugin_dir> <worker_home>
+# Interactive pi; sessions isolated to the per-worker dir; reproducibility flags.
+harness_launch_argv() {
+  local home="$5"
+  local model="${CSD_PI_MODEL:-openai-codex/gpt-5.5}"
+  printf '%s\n' \
+    "$(harness_bin)" \
+    --session-dir "$home/sessions" \
+    --model "$model" \
+    --no-extensions --no-skills
+}
+
+# PI_CODING_AGENT_DIR (staged auth) + PI_CODING_AGENT_SESSION_DIR (worker sessions).
+harness_env_args() {
+  local home="${_CSD_CURRENT_WORKER_HOME:-}"
+  WORKER_ENV_ARGS=(-e "PI_CODING_AGENT_DIR=${home}" -e "PI_CODING_AGENT_SESSION_DIR=${home}/sessions")
+}
+
+# Start the poller in a second tmux window of the worker's session (dies with it).
+harness_post_launch() {
+  local tmux_name="$1"
+  local sd="${_CSD_CURRENT_WORKER_HOME:-}/sessions"
+  tmux new-window -t "$tmux_name" -n csd-poll \
+    "exec '$CSD_PATH' poll pi '$sd' '$_CSD_WORKER_DIR' '$tmux_name'"
+}
+
+# derive readiness: wait for the composer, else settle (first send re-confirms).
+harness_await_ready() {
+  local tmux_name="$1" deadline=$((SECONDS + 20)) pane
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    pane=$(tmux capture-pane -t "$tmux_name" -p 2>/dev/null || true)
+    echo "$pane" | grep -q '%/272k\|auto)' && return 0   # pi status bar
+    sleep 0.5
+  done
+  return 0
+}
+
+# transcript path recorded by the poller; read from meta.
+harness_transcript_path() {
+  local sid="$1"
+  jq -r '.transcript_path // empty' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null
+}
+
+# Render the last turn of a pi session file as markdown.
+harness_parse_turn() {
+  local sf="$1"
+  [ -f "$sf" ] || { echo "No session at $sf" >&2; return 1; }
+  local start=""
+  start=$(grep -n '"role":"user"' "$sf" | tail -1 | cut -d: -f1) || start=""
+  [ -z "$start" ] && start=1
+  tail -n +"$start" "$sf" | jq -r '
+    select(.type=="message") | .message as $m |
+    if   $m.role=="user"      then "**[user]** " + ([$m.content[]?|select(.type=="text").text]|join(""))+"\n"
+    elif $m.role=="assistant" then
+      ([$m.content[]? |
+        if .type=="text" then .text
+        elif .type=="toolCall" then "\n**Tool: "+.name+"**\n```\n"+(.arguments|tostring)+"\n```"
+        else empty end] | join(""))+"\n"
+    elif $m.role=="toolResult" then "**Result:**\n```\n" + ([$m.content[]?|select(.type=="text").text]|join(""))+"\n```\n"
+    else empty end' 2>/dev/null
+}
+harness_count_text() {
+  local sf="$1" c
+  [ -f "$sf" ] || { echo 0; return; }
+  c=$(grep -c '"role":"assistant"' "$sf" 2>/dev/null) || c=0
+  echo "$c"
+}
+harness_last_text() {
+  local sf="$1"
+  [ -f "$sf" ] || return 0
+  grep '"role":"assistant"' "$sf" \
+    | jq -rs 'map(select(.message.role=="assistant")) | last | [.message.content[]?|select(.type=="text").text]|join("")' 2>/dev/null || true
+}
+```
+
+- [ ] **Step 4: Run the test** — `bash tests/test-csd-pi.sh` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat(csd): pi prepare/launch/env/post-launch(poller)/parser slots (PRI-2096)"
+```
+
+---
+
+## Task 3: The `csd poll` internal subcommand
+
+**Files:** `scripts/csd`, `scripts/_lib.sh`
+
+- [ ] **Step 1: Add `poll` to the dispatch as an internal subcommand**
+
+In `csd`'s main dispatch, before the TOP_LEVEL/PER_WORKER classification, handle `poll` directly (it is started by the spine in a tmux window, not user-facing):
+
+```bash
+if [ "${1:-}" = "poll" ]; then
+  shift
+  _phar="${1:?poll <harness> <session_dir> <worker_dir> <tmux_name>}"; shift
+  _load_driver "$_phar"
+  harness_poll "$@"
+  exit $?
+fi
+```
+Place this immediately after `source "$SCRIPT_DIR/_lib.sh"` and the constants, before the `--worker` parse loop.
+
+- [ ] **Step 2: Add a test** — append to `tests/test-csd-pi.sh`: run `csd poll pi <sd> <wd> <missing-tmux>` and assert it self-registers + exits.
+
+```bash
+SD3=$(mktemp -d); WD3=$(mktemp -d)
+SID3="019e0000-0000-7000-8000-0000000000bb"
+printf '{"type":"session","version":3,"id":"%s","cwd":"/w"}\n' "$SID3" > "$SD3/x_${SID3}.jsonl"
+printf '{"type":"message","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"Z"}]}}\n' >> "$SD3/x_${SID3}.jsonl"
+timeout 10 bash "$SCR/csd" poll pi "$SD3" "$WD3" "no-tmux-$$" >/dev/null 2>&1 || true
+[ -f "$WD3/$SID3.meta" ] && pass "csd poll self-registers" || fail "csd poll" "no meta"
+rm -rf "$SD3" "$WD3"
+```
+
+- [ ] **Step 3: Run + verify** — `bash tests/test-csd-pi.sh` → PASS; full suite green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "feat(csd): csd poll internal subcommand drives harness_poll (PRI-2096)"
+```
+
+---
+
+## Task 4: fake-pi integration test (launch → poll → read-turn → multi-turn converse)
+
+**Files:** `tests/fixtures/fake-pi`, `tests/test-csd-pi.sh`
+
+- [ ] **Step 1: Write `tests/fixtures/fake-pi`** — writes a session JSONL (boot turn) under `--session-dir`/`PI_CODING_AGENT_SESSION_DIR`, prints the status-bar glyphs (for await_ready), then confirms each submitted prompt with a fresh `user` record (so the poller emits `user_prompt_submit`) but no new `stop` (multi-turn regression, mirroring fake-codex).
+
+```bash
+#!/bin/bash
+sd="${PI_CODING_AGENT_SESSION_DIR:-.}"
+while [ $# -gt 0 ]; do case "$1" in --session-dir) sd="$2"; shift 2 ;; *) shift ;; esac; done
+SID="019efake-0000-7000-8000-$(printf '%012d' "$$")"
+SF="$sd/2026-01-01T00-00-00-000Z_${SID}.jsonl"; mkdir -p "$sd"
+{
+  printf '{"type":"session","version":3,"id":"%s","cwd":"."}\n' "$SID"
+  printf '{"type":"message","message":{"role":"user","content":[{"type":"text","text":"boot"}]}}\n'
+  printf '{"type":"message","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"FAKE_PI_DONE"}]}}\n'
+} > "$SF"
+echo "0.0%/272k (auto)"   # status bar -> harness_await_ready
+while IFS= read -r _line; do
+  printf '{"type":"message","message":{"role":"user","content":[{"type":"text","text":"next"}]}}\n' >> "$SF"
+done
+```
+
+- [ ] **Step 2: Append the integration test** to `tests/test-csd-pi.sh` (mirrors the codex integration test): launch `--harness pi` with `CSD_PI_BIN=fake-pi`, assert `read-turn` shows `FAKE_PI_DONE`, `status` idle, meta `harness=pi`, and a 2nd `converse` does **not** echo the stale boot answer.
+
+```bash
+FAKE="$SCRIPT_DIR/fixtures/fake-pi"; chmod +x "$FAKE" 2>/dev/null || true
+IHOME=$(mktemp -d); mkdir -p "$IHOME/.claude" "$IHOME/.pi/agent"; touch "$IHOME/.claude/.claude-session-driver-consent"
+echo '{}' > "$IHOME/.pi/agent/auth.json"
+IWDIR=$(mktemp -d); ITN="test-pi-$$"; IWD=$(mktemp -d)
+run_csd(){ CSD_WORKER_DIR="$IWDIR" CSD_PI_BIN="$FAKE" HOME="$IHOME" bash "$SCR/csd" "$@"; }
+run_csd launch --harness pi "$ITN" "$IWD" >/dev/null 2>&1 || true
+sleep 2
+OUT=$(run_csd --worker "$ITN" read-turn 2>/dev/null || true)
+echo "$OUT" | grep -q "FAKE_PI_DONE" && pass "pi read-turn renders the turn" || fail "pi read-turn" "got: $OUT"
+ST=$(run_csd --worker "$ITN" status 2>/dev/null || true)
+[ "$ST" = "idle" ] && pass "pi status idle" || fail "pi status" "got: $ST"
+M=$(ls "$IWDIR"/*.meta 2>/dev/null | head -1)
+[ -n "$M" ] && [ "$(jq -r '.harness' "$M")" = "pi" ] && pass "pi meta self-registered" || fail "pi meta" "missing"
+OUT2=$(run_csd --worker "$ITN" converse "again" 4 2>/dev/null || true)
+echo "$OUT2" | grep -q FAKE_PI_DONE && fail "pi converse stale" "echoed prior: $OUT2" || pass "pi converse not stale"
+run_csd --worker "$ITN" stop >/dev/null 2>&1 || true
+tmux kill-session -t "$ITN" 2>/dev/null || true
+rm -rf "$IHOME" "$IWD" "$IWDIR"
+```
+
+- [ ] **Step 3: Run + full suite** — `bash tests/test-csd-pi.sh` → PASS; `for t in tests/test-*.sh; do bash "$t"; done` all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/fixtures/fake-pi tests/test-csd-pi.sh
+git commit -m "test(csd): fake-pi integration + multi-turn regression (PRI-2096)"
+```
+
+---
+
+## Task 5: Gated real-pi multi-turn smoke
+
+**Files:** `tests/smoke-pi-real.sh`
+
+- [ ] **Step 1: Write `tests/smoke-pi-real.sh`** — mirror `smoke-codex-real.sh`: self-contained HOME (consent + staged `~/.pi/agent`), `CSD_PI_BIN` = the real pi path, two `converse`s (ALPHA/BRAVO), assert turn 2 = BRAVO not stale ALPHA, then `stop`. Gate on `CSD_RUN_REAL_PI=1`.
+
+- [ ] **Step 2: Run it once** — `CSD_RUN_REAL_PI=1 bash tests/smoke-pi-real.sh` → multi-turn pi conversation drives through csd.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/smoke-pi-real.sh
+git commit -m "test(csd): gated real-pi multi-turn smoke (PRI-2096)"
+```
+
+---
+
+## Final verification
+- [ ] Full suite green (22 scripts incl. test-csd-pi.sh) from a clean slate.
+- [ ] Real-pi smoke passed once.
+- [ ] `csd launch --harness pi <name> <cwd>` → multi-turn `converse` → `read-turn` → `stop` works against real pi.
+- [ ] Claude + Codex paths unchanged (all prior tests green).
+
+## Self-Review
+- **Spec coverage:** poller control plane → Tasks 1,3; record→event map (Appendix A/prototype) → Task 1; derive launch via poller-in-tmux-window → Task 2; multi-turn regression → Task 4; real validation → Task 5.
+- **Reused from Phase 2 (no change):** derive `cmd_launch` branch, sidecar+dispatcher fallback, `cmd_send`/`cmd_converse` pre-registration, `_worker_tmux_name`, `cmd_stop` cleanup, `cmd_adopt` reject.
+- **Risks for the reviewer:** (1) `harness_poll`'s per-line `jq` in a `set -e` driver — confirm the `|| ""` guards hold and a malformed `message_update` line (Pi can emit multi-MB lines) doesn't abort the loop. (2) `harness_post_launch` starts the poller in a tmux *window* — confirm `kill-session` reaps it and `cmd_stop`'s `_worker_tmux_name` still resolves. (3) the poller and `cmd_send` both consult the events file — confirm no race on first registration. (4) `harness_await_ready` greps the pi status bar — brittle across versions (best-effort, first send re-confirms). (5) Pi may emit `message_update` cumulative-state records in some modes; confirm the native (non-`--mode json`) interactive format used here only emits discrete `message` records (the prototype showed it does).

--- a/docs/superpowers/plans/2026-06-06-csd-multiharness-phase3-pi.md
+++ b/docs/superpowers/plans/2026-06-06-csd-multiharness-phase3-pi.md
@@ -239,7 +239,9 @@ harness_env_args() {
 harness_post_launch() {
   local tmux_name="$1"
   local sd="${_CSD_CURRENT_WORKER_HOME:-}/sessions"
-  tmux new-window -t "$tmux_name" -n csd-poll \
+  # -d: do NOT switch the active window — cmd_send targets the session's active
+  # window, which must stay pi's (window 0), not the poller's (B1 from review).
+  tmux new-window -d -t "$tmux_name" -n csd-poll \
     "exec '$CSD_PATH' poll pi '$sd' '$_CSD_WORKER_DIR' '$tmux_name'"
 }
 
@@ -328,7 +330,7 @@ SD3=$(mktemp -d); WD3=$(mktemp -d)
 SID3="019e0000-0000-7000-8000-0000000000bb"
 printf '{"type":"session","version":3,"id":"%s","cwd":"/w"}\n' "$SID3" > "$SD3/x_${SID3}.jsonl"
 printf '{"type":"message","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"Z"}]}}\n' >> "$SD3/x_${SID3}.jsonl"
-timeout 10 bash "$SCR/csd" poll pi "$SD3" "$WD3" "no-tmux-$$" >/dev/null 2>&1 || true
+bash "$SCR/csd" poll pi "$SD3" "$WD3" "no-tmux-$$" >/dev/null 2>&1 || true  # self-exits vs missing tmux
 [ -f "$WD3/$SID3.meta" ] && pass "csd poll self-registers" || fail "csd poll" "no meta"
 rm -rf "$SD3" "$WD3"
 ```

--- a/docs/superpowers/specs/2026-06-05-csd-multiharness-design.md
+++ b/docs/superpowers/specs/2026-06-05-csd-multiharness-design.md
@@ -272,3 +272,55 @@ carries `{name, arguments}` (full tool input) and the `toolResult` carries
 message:{role, content:[{type}], stopReason, usage?}}`; roles `user` /
 `assistant` / `toolResult`; content types `text` / `toolCall`. This is the
 empirical basis for the record→event map above.
+
+## Appendix B — Derive-id identity flow (validated end-to-end against real codex 0.134)
+
+`assign` (Claude) and `derive` (Codex, Pi) differ only in **when and by whom the
+worker's `<sid>.meta` and `<sid>.events.jsonl` are created**. Everything
+downstream (`resolve_session`, `wait-for-turn`, `status`, `read-events`,
+`converse`'s turn-diff) is **identical** once those files exist.
+
+- **assign (Claude):** the caller picks the id; `cmd_launch` pre-writes
+  `<sid>.meta` and the worker emits `session_start` at boot. Unchanged from Phase 1.
+- **derive (Codex/Pi):** the harness mints its own id. The worker's control-plane
+  producer (Codex's hook / Pi's poller) **self-registers** `<sid>.meta` (carrying
+  `tmux_name`, `session_id`, `cwd`, `transcript_path`, `harness`) and appends to
+  `<sid>.events.jsonl` — keyed by the same `<sid>`. No formula is used for the
+  transcript path; it is read from the self-registered meta.
+
+**Codex launch sequence (proven by the e2e prototype):**
+1. Create per-worker `CODEX_HOME=$_CSD_WORKER_DIR/homes/<tmux_name>`; stage the
+   operator's `~/.codex/auth.json` into it (subscription).
+2. Write `config.toml`: `model`, `[projects."<cwd>"] trust_level="trusted"`, and
+   `[[hooks.<Event>]]` for SessionStart/UserPromptSubmit/PreToolUse/Stop/SessionEnd,
+   each `command = "<plugin>/hooks/emit-event-codex <tmux_name> <cwd> <worker_dir>"`.
+3. Launch interactive `codex --dangerously-bypass-approvals-and-sandbox
+   --dangerously-bypass-hook-trust -C <cwd>` in tmux with `CODEX_HOME` set.
+4. **Dismiss the trust gate:** poll the pane for "Hooks need review"/trust; send
+   `2` + Enter if present (the bypass flag does NOT auto-skip it). Bounded.
+5. **Readiness is NOT `session_start`** — that fires at the first prompt, not boot.
+   Treat the worker ready once the pane shows the composer (or a short settle).
+6. Write the shim and return. No meta yet — the hook self-registers it on the
+   first prompt.
+
+**`emit-event-codex` (self-registering hook, validated):** reads the hook JSON on
+stdin; on first event creates `<sid>.meta` from the payload's `session_id` +
+`transcript_path` (plus the baked `tmux_name`/`cwd`); maps the event name
+(Codex's names equal Claude's) and appends the normalized record to
+`<sid>.events.jsonl`. Note `tool_name` in hook payloads is normalized (`"Bash"`)
+vs the rollout's `"exec_command"`.
+
+**The one new spine behavior — the pre-registration window.** Between launch and
+the first prompt, no `<sid>.meta` exists, so `resolve_session(worker)` cannot find
+a `session_id`. The first `send`/`converse` must therefore: (a) send keys to the
+tmux session by **`tmux_name`** (always known — the shim sets `--worker
+<tmux_name>`), not via a resolved sid; then (b) poll for self-registration (a meta
+whose `tmux_name` matches) to learn the `session_id`; then (c) proceed exactly as
+today (wait for `stop` in `<sid>.events.jsonl`, render the rollout). The prototype
+showed `session_start`/`user_prompt_submit` self-register within ~1s of the
+submit, so this window is short.
+
+**Codex turn parser** consumes the rollout `response_item` records
+(`payload.type` ∈ message / reasoning / function_call / function_call_output) and
+`event_msg` (agent_message / task_complete); render to the same markdown shape as
+`harness_parse_turn` for Claude.

--- a/docs/superpowers/specs/2026-06-05-csd-multiharness-design.md
+++ b/docs/superpowers/specs/2026-06-05-csd-multiharness-design.md
@@ -1,0 +1,274 @@
+# CSD Multi-Harness Support — Design
+
+- **Date:** 2026-06-05
+- **Status:** Approved (design); ready for implementation plan
+- **Author:** Kaylee@a55760bc
+- **Topic:** Let CSD drive Codex and Pi workers alongside Claude Code
+
+## Goal
+
+Today CSD (claude-session-driver) drives exactly one harness: Claude Code. This
+design generalizes it to drive **OpenAI Codex** and **Pi** workers through the
+same CLI, the same tmux model, and the same controller-facing contract — so a
+controller can `launch` / `converse` / `wait-for-turn` / `read-turn` / `stop` a
+Codex or Pi worker without knowing or caring which harness is inside the pane.
+
+CSD becomes **"Coding-agent Session Driver"** (the `csd` name is retained).
+
+### Non-goals
+
+- No cost/pricing layer (Pi exposes inline cost; we ignore it for now).
+- No cross-harness *canonical* transcript schema. Each harness keeps a native,
+  per-harness turn parser.
+- No change to the controller-facing command surface or its semantics.
+- No sandboxing/isolation beyond what CSD does today (workers run on the host).
+
+## Background: how CSD drives Claude today
+
+CSD is a **PTY puppeteer + transcript reader**, not an API client. It runs
+`claude` interactively in a tmux pane and reads two files Claude leaves on disk.
+Everything rests on **two planes**:
+
+- **Control plane** — `/tmp/claude-workers/<sid>.events.jsonl`, written by CSD's
+  own plugin. Claude's lifecycle hooks fire `emit-event`, which appends
+  normalized events: `session_start`, `user_prompt_submit`, `pre_tool_use` (tool
+  name + input), `stop`, `session_end`. This is the **turn-boundary and liveness
+  signal**: `wait-for-turn` blocks on `stop`/`session_end`; `status` reads the
+  last event; `send` confirms submission via `user_prompt_submit`.
+- **Data plane** — `~/.claude/projects/<encoded-cwd>/<sid>.jsonl`, Claude's own
+  transcript. `read-turn` and `converse` parse it with `jq` to reconstruct the
+  text/thinking/tool calls of a turn.
+
+The split is the core design move: **wait on the cheap control plane, then read
+the schema-bound data plane.** CSD depends on seven harness capabilities
+("ports"): (1) a caller-assigned, stable session id; (2) prompt injection into a
+live REPL via bracketed paste + Enter; (3) a pluggable lifecycle-hook system; (4)
+a turn-end signal; (5) a persisted, parseable transcript at a derivable path; (6)
+permission bypass + no human-question blocking; (7) auth via process env.
+
+All seven are currently satisfied by Claude-specific flags, paths, and a schema
+smeared across `cmd_launch`, `cmd_send`, `cmd_stop`, `cmd_read_turn`,
+`cmd_converse`, `emit-event`, and `_build_worker_env_args`.
+
+## Core idea: keep the spine, swap the adapter
+
+The orchestration **spine** is already harness-agnostic and stays untouched:
+tmux lifecycle, the meta/shim/`resolve_session` identity model, `list`, the
+wait-then-read pattern, `converse`, consent, the reproduce line.
+
+The **adapter** — the seven ports — moves behind a per-harness **driver**: a
+sourced bash file `drivers/<harness>.sh` defining a fixed set of slot functions.
+`csd` calls slots; it never names a harness. A worker's `.meta` records its
+`harness`, so every later command re-sources the right driver.
+
+*(Alternatives rejected: separate per-harness binaries, or `case $harness` inside
+every command. Sourced driver files keep the spine harness-blind, let each driver
+be read and tested in isolation, and match how `_lib.sh` is already sourced.)*
+
+### The driver interface (slots)
+
+```
+harness_launch_argv   <tmux_name> <cwd> <session_id|""> <plugin_dir>  # argv to exec in tmux
+harness_quit_keys                                                      # "/exit" | "/quit" | "C-c"
+harness_id_strategy                                                    # "assign" | "derive"
+harness_resolve_session_id  <tmux_name> <cwd>                          # derive: find the real sid post-launch
+harness_control_plane                                                  # "hooks" | "poll"
+harness_transcript_path     <session_id> <cwd>                         # path or glob
+harness_parse_turn          <transcript> [--full]                     # native JSONL -> markdown
+harness_count_text          <transcript>                              # converse: count assistant text msgs
+harness_last_text           <transcript>                              # converse: extract last assistant text
+harness_env_args                                                      # the -e VAR=… isolation pins
+```
+
+Two slots carry the only real branching; the rest are parameters:
+
+- **`control_plane = hooks | poll`** — `hooks`: load the plugin, the harness
+  self-emits events (Claude, Codex). `poll`: spawn a tailer that synthesizes
+  events from the transcript (Pi).
+- **`id_strategy = assign | derive`** — `assign`: caller picks the id at launch
+  (`claude --session-id`). `derive`: the harness mints its own id; CSD launches
+  it pointed at a **per-worker config/session directory**, so the worker's
+  session is the unique newest file in that dir, and its id is read back from the
+  file (Codex, Pi).
+
+## Control plane: one `events.jsonl`, two producers
+
+The load-bearing invariant: **all downstream consumers
+(`wait-for-turn`, `status`, `read-events`, `converse`) read only
+`events.jsonl` and are completely unchanged.** What varies is *who writes it*:
+
+```
+Claude: claude TUI ─hooks─▶ emit-event ─┐
+Codex:  codex  TUI ─hooks─▶ emit-event ─┼─▶ events.jsonl ─▶ [unchanged spine]
+Pi:     pi     TUI ─writes─▶ session.jsonl │
+                                  └─▶ csd poll (tail+map) ─┘   ← the one net-new component
+```
+
+For Claude and Codex, the harness's own hook system runs `emit-event`. For Pi,
+which has **no hook system**, a small tailer (`csd poll <sid>`) watches the Pi
+session file and maps its records into the same event vocabulary.
+
+### Why polling is sufficient — and per-tool, not just per-turn
+
+Empirically verified (see Appendix A). Pi writes **each step as its own record
+the instant it happens**, and each record is self-describing:
+
+| Pi session record | synthesized event |
+|---|---|
+| `{"type":"session", id, cwd}` (line 1) | `session_start` |
+| `message` role=`user` | `user_prompt_submit` |
+| `message` role=`assistant`, `stopReason:"toolUse"`, content `toolCall{name,arguments}` | `pre_tool_use` (`tool`=name, `tool_input`=arguments) — emitted **before** the tool runs |
+| `message` role=`toolResult` `{toolName, isError, content}` | `post_tool_use` (new, optional; Claude/Codex don't emit this today) |
+| `message` role=`assistant`, `stopReason:"stop"` (or `error`/other terminal) | `stop` |
+| tmux pane gone | `session_end` |
+
+The decisive rule: **`stopReason:"toolUse"` is a tool step (the turn continues);
+any other terminal `stopReason` (`stop`, `error`, …) is turn-end.** A multi-tool
+turn produces interleaved `toolUse` assistant / `toolResult` records, then one
+terminal `stop`.
+
+This gives Pi **full parity** with the hook control plane (per-tool *and*
+turn-end, with tool name + input) under the uniform tmux-TUI model — no RPC
+needed. Pi's RPC mode would add only token-level streaming deltas, a submit-ack,
+and `abort`; none are required for CSD's observe-and-orchestrate loop.
+
+### The poller component (`csd poll`)
+
+- **Lifecycle:** runs as a **second tmux window** inside the worker's session, so
+  `tmux kill-session` reaps it for free (no PID bookkeeping) and it is
+  inspectable for debugging.
+- **Job:** tail the Pi session JSONL, recognize complete lines only (guard
+  against half-written and multi-MB lines), map records → events, append to
+  `events.jsonl`. Emit `session_end` when the worker pane dies.
+- **Robustness:** treat any terminal `stopReason` other than `toolUse` as
+  turn-end (handles `error` and future variants); never block on a partial line.
+
+The poller is the **only** net-new logic. `launch` gains one branch:
+`hooks`-harness loads the plugin; `poll`-harness opens the poller window.
+
+## Per-harness adapters
+
+| slot | claude | codex | pi |
+|---|---|---|---|
+| launch argv | `claude --session-id <id> --plugin-dir <p> --settings '{"skipDangerousModePermissionPrompt":true}' --dangerously-skip-permissions --disallowed-tools AskUserQuestion` | `codex --yolo` (interactive); hooks + trust via per-worker `CODEX_HOME` config | `pi --session-dir <wd>/.csd/sessions --model <route>` |
+| id strategy | **assign** | **derive** (newest rollout in worker `CODEX_HOME`) | **derive** (newest file in `--session-dir`) |
+| quit keys | `/exit` | `/quit` | `C-c` *(verify clean flush)* |
+| control plane | hooks | hooks (same `emit-event`, + Codex event-name map) | **poll** |
+| turn-end | `stop` event | `Stop` event / `task_complete` | assistant `stopReason:"stop"` |
+| transcript | `~/.claude/projects/<enc>/<id>.jsonl` | `$CODEX_HOME/sessions/Y/M/D/rollout-*-<id>.jsonl` | `<session-dir>/<ts>_<id>.jsonl` |
+| env isolation | provider-env pin/clear | per-worker `CODEX_HOME` | per-worker `PI_CODING_AGENT_DIR` + `--session-dir` |
+
+### Claude (`drivers/claude.sh`)
+Extracts today's behavior **verbatim** — same flags, same `~/.claude/projects`
+path formula, same `_build_worker_env_args` provider-env logic (now
+`harness_env_args`), same `cmd_read_turn` jq (now `harness_parse_turn`). The
+control plane is the existing plugin/hooks. This driver is the regression anchor:
+the refactor must change zero Claude behavior.
+
+### Codex (`drivers/codex.sh`)
+- **Launch:** interactive `codex` with `--yolo` (skip approvals/sandbox; the
+  worker is the trust boundary, as with Claude's `--dangerously-skip-permissions`).
+  Codex has no `AskUserQuestion`-style blocker; `--yolo` / approvals-never
+  suffices.
+- **Control plane = hooks.** Codex's hook system is a near-clone of Claude's:
+  command hooks read JSON on stdin (`session_id`, `transcript_path`, `cwd`,
+  `hook_event_name`, `tool_name`/`tool_input` on PreToolUse) and the event set
+  matches (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `Stop`,
+  `SessionEnd`). The **same `emit-event`** script handles Codex; we add Codex's
+  event-name → snake_case mapping. Hooks are registered + pre-trusted via a config
+  written into the worker's private `CODEX_HOME` (avoids the interactive
+  hook-trust gate; `--enable hooks` if the feature flag is required).
+- **Id strategy = derive.** No `--session-id` flag. A per-worker `CODEX_HOME`
+  means one session under `<CODEX_HOME>/sessions/**`; `harness_resolve_session_id`
+  globs the newest `rollout-*-<uuid>.jsonl` and reads `session_meta.payload.id`.
+  (The SessionStart hook payload also carries `session_id` + `transcript_path`;
+  either source works. `emit-event` recognizes "this is a worker" by running
+  under the worker's private `CODEX_HOME`, then keys `events.jsonl` by the
+  `session_id` in its stdin payload.)
+- **Transcript:** date-sharded; `harness_transcript_path` globs
+  `<CODEX_HOME>/sessions/**/rollout-*-<id>.jsonl`. Parser maps Codex
+  `response_item`/`event_msg` records (agent message text, reasoning,
+  function_call/output) → markdown.
+
+### Pi (`drivers/pi.sh` + `csd poll`)
+- **Launch:** interactive `pi --session-dir <wd>/.csd/sessions --model <route>`.
+  Pi requires an explicit model **route** (`<pi-provider>/<model>`, e.g.
+  `openai-codex/gpt-5.5` for subscription, `openrouter/<vendor>/<model>` for
+  token) — Pi's default provider is `google`, which has no creds here. The route
+  is a launch parameter.
+- **Control plane = poll.** As above.
+- **Id strategy = derive.** `harness_resolve_session_id` reads the newest
+  `<session-dir>/<ts>_<uuid>.jsonl` and takes `id` from line 1.
+- **Permission bypass:** Pi's interactive tools run unattended (no
+  `AskUserQuestion`-style blocker observed); no explicit yolo flag is needed.
+- **Auth/env isolation:** per-worker `PI_CODING_AGENT_DIR` + `--session-dir`;
+  creds resolve from `~/.pi/agent/auth.json` (OpenRouter key + Codex OAuth blob).
+
+## Identity & naming changes
+
+- **State dir:** `/tmp/claude-workers` → `/tmp/csd-workers`, with a back-compat
+  symlink `/tmp/claude-workers → /tmp/csd-workers` so live workers' baked shim
+  paths keep resolving across the upgrade.
+- **Binary resolution:** `CSD_CLAUDE_BIN` → a per-harness `harness_bin` (e.g.
+  `CSD_CLAUDE_BIN`, `CSD_CODEX_BIN`, `CSD_PI_BIN`), each defaulting to the bare
+  command name on `PATH`.
+- **`launch` gains a harness selector**, e.g. `csd launch --harness codex <name>
+  <cwd> [-- harness-args...]` (default `claude` for back-compat). The chosen
+  harness is written to `.meta`.
+- The `--worker` shim contract, `resolve_session`, and all per-worker subcommands
+  are unchanged.
+
+## Transcript handling
+
+Three small native `parse_turn` jq scripts (one per harness), not a shared
+normalization layer. Each produces the same markdown shape `read-turn` emits
+today (prompt / thinking / tool calls / results, tool results truncated to 5
+lines without `--full`). `converse`'s `count_text` / `last_text` helpers likewise
+become per-harness, reading each native schema. The wait itself is unchanged — it
+keys off `events.jsonl`, which every harness now populates.
+
+## What gets built (sequence)
+
+1. **Refactor to drivers (no behavior change):** extract `drivers/claude.sh`;
+   route `cmd_launch`/`cmd_stop`/`cmd_read_turn`/`cmd_converse`/`harness_env_args`
+   through slots; generalize `/tmp/claude-workers` → `/tmp/csd-workers` + symlink.
+   Existing Claude tests must pass untouched.
+2. **Codex driver:** `drivers/codex.sh`; add Codex event-name mapping to
+   `emit-event`; per-worker `CODEX_HOME` hook config + trust; derive-id;
+   Codex turn parser. New tests.
+3. **Pi driver + poller:** `csd poll` tailer (record→event map from Appendix A);
+   `drivers/pi.sh`; derive-id; Pi turn parser; poller-as-tmux-window lifecycle.
+   New tests.
+
+## Open questions (to verify during implementation; none threaten the design)
+
+- **Pi send + quit:** confirm bracketed-paste + Enter submits in Pi's interactive
+  composer (the probe used an initial-prompt positional, not `send`); confirm a
+  clean quit key (probe used `C-c` then kill-session).
+- **Codex hook trust/feature wiring:** exact `CODEX_HOME` config to pre-trust
+  command hooks and whether `--enable hooks` / `-c features.hooks=true` is needed
+  on this version.
+- **Pi `stopReason` variants** beyond `stop` / `toolUse` / `error`.
+- **Codex submit-confirmation:** Codex emits `UserPromptSubmit`; confirm the
+  send-retry loop keys off it the same way Claude does.
+
+## Appendix A — Pi flush-timing probe (evidence)
+
+One interactive Pi session in tmux, forced a `bash` tool call with a known 6s
+delay, polled the session file every 0.4s. Observed arrival timeline:
+
+```
+T+2.5  session header
+T+2.5  message role=user                                    (prompt)
+T+2.5  message role=assistant stopReason=toolUse  toolCall  (bash: sleep 6 && echo …)
+T+8.8  message role=toolResult  isError=false               (after the 6s sleep)
+T+9.7  message role=assistant stopReason=stop     text      (final reply)
+```
+
+The tool-call record lands **~6s before** its result — Pi flushes each step
+incrementally, so the poller sees a tool *before it runs*. The `toolCall` record
+carries `{name, arguments}` (full tool input) and the `toolResult` carries
+`{toolName, isError, content}`. Record schema: `{type, id, parentId, timestamp,
+message:{role, content:[{type}], stopReason, usage?}}`; roles `user` /
+`assistant` / `toolResult`; content types `text` / `toolCall`. This is the
+empirical basis for the record→event map above.

--- a/hooks/emit-event
+++ b/hooks/emit-event
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Worker state dir (kept in sync with _lib.sh; honors CSD_WORKER_DIR).
+WORKER_DIR="${CSD_WORKER_DIR:-/tmp/csd-workers}"
+
 # Hook script called by Claude Code for session lifecycle events.
 # Reads hook input JSON from stdin and appends a JSONL event line
 # to /tmp/claude-workers/<session_id>.events.jsonl.
@@ -31,7 +34,7 @@ fi
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id')
 
 # Only emit events for managed worker sessions.
-if [ ! -f "/tmp/claude-workers/${SESSION_ID}.meta" ]; then
+if [ ! -f "$WORKER_DIR/${SESSION_ID}.meta" ]; then
   exit 0
 fi
 
@@ -48,7 +51,7 @@ case "$HOOK_EVENT" in
   *)                EVENT=$(echo "$HOOK_EVENT" | sed 's/\([A-Z]\)/_\L\1/g' | sed 's/^_//') ;;
 esac
 
-mkdir -p /tmp/claude-workers
+mkdir -p "$WORKER_DIR"
 
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -69,7 +72,7 @@ else
     '{ts: $ts, event: $event}')
 fi
 
-EVENT_FILE="/tmp/claude-workers/${SESSION_ID}.events.jsonl"
+EVENT_FILE="$WORKER_DIR/${SESSION_ID}.events.jsonl"
 echo "$EVENT_JSON" >> "$EVENT_FILE"
 
 # For Stop events, approve so we never block the agent

--- a/hooks/emit-event-codex
+++ b/hooks/emit-event-codex
@@ -39,7 +39,7 @@ case "$EV" in
   PostToolUse)      e=post_tool_use ;;
   Stop)             e=stop ;;
   SessionEnd)       e=session_end ;;
-  *)                e=$(echo "$EV" | sed 's/\([A-Z]\)/_\L\1/g; s/^_//') ;;
+  *)                e=$(echo "$EV" | sed 's/\([A-Z]\)/_\1/g; s/^_//' | tr '[:upper:]' '[:lower:]') ;;
 esac
 
 ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/hooks/emit-event-codex
+++ b/hooks/emit-event-codex
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+# Codex lifecycle hook for csd. Self-registers the worker meta and appends
+# normalized events to <sid>.events.jsonl. Args (baked into the per-worker
+# CODEX_HOME config.toml hook command): <tmux_name> <cwd> <worker_dir>.
+#
+# Codex mints its own session id; this hook learns it (and the rollout path)
+# from the SessionStart payload and creates <sid>.meta on first sight, so the
+# controller can resolve the worker by tmux_name once the first prompt fires.
+
+TN="${1:-}"; CWD="${2:-}"; WD="${3:-}"
+[ -z "$WD" ] && exit 0
+
+# Read all of stdin with a bounded timeout (-r so escaped JSON survives; see
+# hooks/emit-event for the #9 timeout / #15 Stop-exit rationale).
+INPUT=""
+IFS= read -t 5 -d '' -r INPUT || true
+[ -z "$INPUT" ] && exit 0
+printf '%s' "$INPUT" | jq -e . >/dev/null 2>&1 || exit 0
+
+SID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty')
+[ -z "$SID" ] && exit 0
+EV=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty')
+TP=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty')
+
+mkdir -p "$WD"
+
+# Self-register the worker meta on first event.
+if [ ! -f "$WD/$SID.meta" ]; then
+  jq -n --arg tn "$TN" --arg sid "$SID" --arg cwd "$CWD" --arg tp "$TP" \
+    '{tmux_name:$tn, session_id:$sid, cwd:$cwd, transcript_path:$tp, harness:"codex"}' \
+    > "$WD/$SID.meta"
+fi
+
+case "$EV" in
+  SessionStart)     e=session_start ;;
+  UserPromptSubmit) e=user_prompt_submit ;;
+  PreToolUse)       e=pre_tool_use ;;
+  PostToolUse)      e=post_tool_use ;;
+  Stop)             e=stop ;;
+  SessionEnd)       e=session_end ;;
+  *)                e=$(echo "$EV" | sed 's/\([A-Z]\)/_\L\1/g; s/^_//') ;;
+esac
+
+ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+if [ "$e" = pre_tool_use ]; then
+  tool=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""')
+  ti=$(printf '%s' "$INPUT" | jq -c '.tool_input // {}')
+  jq -cn --arg ts "$ts" --arg event "$e" --arg tool "$tool" --argjson ti "$ti" \
+    '{ts:$ts, event:$event, tool:$tool, tool_input:$ti}' >> "$WD/$SID.events.jsonl"
+else
+  jq -cn --arg ts "$ts" --arg event "$e" '{ts:$ts, event:$event}' >> "$WD/$SID.events.jsonl"
+fi
+exit 0

--- a/skills/driving-claude-code-sessions/SKILL.md
+++ b/skills/driving-claude-code-sessions/SKILL.md
@@ -9,9 +9,9 @@ description: Use when acting as a project manager that delegates tasks to other 
 
 You can launch other Claude Code sessions as "workers" in tmux, send them prompts, wait for them to finish, read their output, and hand them off to a human. Workers run with `--dangerously-skip-permissions`, so they execute tool calls without prompting. A plugin (claude-session-driver) emits lifecycle events to a JSONL file so the controller can observe what the worker is doing.
 
-All operations go through a single CLI: `csd`. After launching a worker, the controller receives a **shim path** at `/tmp/claude-workers/bin/<tmux-name>` that bakes in the worker handle. Every per-worker operation goes through that path — no positional state to thread between calls, no absolute skill path to prepend. A small set of environment variables tune behavior; see [Environment variables](#environment-variables) at the bottom.
+All operations go through a single CLI: `csd`. After launching a worker, the controller receives a **shim path** at `/tmp/csd-workers/bin/<tmux-name>` that bakes in the worker handle. Every per-worker operation goes through that path — no positional state to thread between calls, no absolute skill path to prepend. A small set of environment variables tune behavior; see [Environment variables](#environment-variables) at the bottom.
 
-The shim path is deterministic: if you pick a memorable tmux name at launch, you can reconstruct `/tmp/claude-workers/bin/<tmux-name>` whenever you need it. For agents driving via tool calls, that's the right model — shell state doesn't persist between calls, so a `SHIM=...; $SHIM cmd` pattern just adds noise. The examples below use the bare path.
+The shim path is deterministic: if you pick a memorable tmux name at launch, you can reconstruct `/tmp/csd-workers/bin/<tmux-name>` whenever you need it. For agents driving via tool calls, that's the right model — shell state doesn't persist between calls, so a `SHIM=...; $SHIM cmd` pattern just adds noise. The examples below use the bare path.
 
 ## Prerequisites
 
@@ -28,31 +28,31 @@ The CLI lives at `<skill>/scripts/csd`. Three top-level subcommands need the ski
 - `csd list [--all]` — enumerate workers
 - `csd grant-consent` — one-time consent for `--dangerously-skip-permissions`
 
-Once a worker is launched, run subsequent commands against `/tmp/claude-workers/bin/<tmux-name>`:
+Once a worker is launched, run subsequent commands against `/tmp/csd-workers/bin/<tmux-name>`:
 
 ```bash
 SKILL=/abs/path/to/skill/scripts
 $SKILL/csd grant-consent                          # one-time per machine
-$SKILL/csd launch my-task /path/to/project        # stdout: /tmp/claude-workers/bin/my-task
-/tmp/claude-workers/bin/my-task status            # use the shim directly
+$SKILL/csd launch my-task /path/to/project        # stdout: /tmp/csd-workers/bin/my-task
+/tmp/csd-workers/bin/my-task status            # use the shim directly
 ```
 
 Pick a memorable tmux name at launch; the shim path is then deterministic. (You *can* capture it into a shell variable in an interactive shell, but for agent-driven workflows the bare path is simpler — there's no shell state to lose between calls.)
 
 ## Workflow
 
-In examples below, `$SKILL` is the absolute path to `skills/driving-claude-code-sessions/scripts`. `WORKER` is the bare shim path (e.g. `/tmp/claude-workers/bin/my-task`) — substitute the deterministic path for your worker.
+In examples below, `$SKILL` is the absolute path to `skills/driving-claude-code-sessions/scripts`. `WORKER` is the bare shim path (e.g. `/tmp/csd-workers/bin/my-task`) — substitute the deterministic path for your worker.
 
 ### 1. Launch
 
 ```bash
 $SKILL/csd launch my-task /path/to/project
-# stdout: /tmp/claude-workers/bin/my-task
+# stdout: /tmp/csd-workers/bin/my-task
 # stderr: Worker launched. tmux/session_id/cwd/events/reproduce
 ```
 
 `csd launch`:
-- Writes a meta file and a 3-line shim at `/tmp/claude-workers/bin/my-task`
+- Writes a meta file and a 3-line shim at `/tmp/csd-workers/bin/my-task`
 - Starts tmux + claude with the plugin loaded
 - Waits up to 30s for `session_start`
 - Prints the shim path on stdout (one line)
@@ -66,20 +66,20 @@ $SKILL/csd launch my-task /path/to/project -- --model sonnet
 ### 2. Converse (the typical case)
 
 ```bash
-/tmp/claude-workers/bin/my-task converse "Refactor the auth module" 300
+/tmp/csd-workers/bin/my-task converse "Refactor the auth module" 300
 ```
 
 `converse` sends the prompt, waits for the worker to finish, and prints the final assistant text on stdout. For tool-heavy turns where the bare text strips the interesting part, use `--with-turn` to get the full markdown:
 
 ```bash
-/tmp/claude-workers/bin/my-task converse --with-turn "Run the failing tests" 600
+/tmp/csd-workers/bin/my-task converse --with-turn "Run the failing tests" 600
 ```
 
 Multi-turn just works — the wait tracks turn boundaries automatically:
 
 ```bash
-/tmp/claude-workers/bin/my-task converse "Write tests for the auth module" 300
-/tmp/claude-workers/bin/my-task converse "Add edge cases for expired tokens" 300
+/tmp/csd-workers/bin/my-task converse "Write tests for the auth module" 300
+/tmp/csd-workers/bin/my-task converse "Add edge cases for expired tokens" 300
 ```
 
 ### 3. Lower-level control
@@ -87,11 +87,11 @@ Multi-turn just works — the wait tracks turn boundaries automatically:
 If you need to drive the worker more directly:
 
 ```bash
-/tmp/claude-workers/bin/my-task send "Refactor the auth module"     # send without waiting
-/tmp/claude-workers/bin/my-task wait-for-turn 300                   # block until stop or session_end
-/tmp/claude-workers/bin/my-task status                              # idle | working | terminated | gone | unknown
-/tmp/claude-workers/bin/my-task read-turn                           # last turn as markdown (tool results truncated to 5 lines)
-/tmp/claude-workers/bin/my-task read-turn --full                    # last turn with complete tool results
+/tmp/csd-workers/bin/my-task send "Refactor the auth module"     # send without waiting
+/tmp/csd-workers/bin/my-task wait-for-turn 300                   # block until stop or session_end
+/tmp/csd-workers/bin/my-task status                              # idle | working | terminated | gone | unknown
+/tmp/csd-workers/bin/my-task read-turn                           # last turn as markdown (tool results truncated to 5 lines)
+/tmp/csd-workers/bin/my-task read-turn --full                    # last turn with complete tool results
 ```
 
 ### 4. Watching what the worker does
@@ -99,7 +99,7 @@ If you need to drive the worker more directly:
 Every tool call emits a `pre_tool_use` event with the tool name and input. Tail the event stream to watch in real time:
 
 ```bash
-/tmp/claude-workers/bin/my-task read-events --follow &
+/tmp/csd-workers/bin/my-task read-events --follow &
 MONITOR_PID=$!
 # ... do other work ...
 kill $MONITOR_PID
@@ -108,9 +108,9 @@ kill $MONITOR_PID
 Or pull events after the fact:
 
 ```bash
-/tmp/claude-workers/bin/my-task read-events                       # all events
-/tmp/claude-workers/bin/my-task read-events --last 5
-/tmp/claude-workers/bin/my-task read-events --type pre_tool_use
+/tmp/csd-workers/bin/my-task read-events                       # all events
+/tmp/csd-workers/bin/my-task read-events --last 5
+/tmp/csd-workers/bin/my-task read-events --type pre_tool_use
 ```
 
 `--type` accepts one of: `session_start`, `user_prompt_submit`, `pre_tool_use`, `stop`, `session_end`. Unknown event names fail fast.
@@ -118,25 +118,25 @@ Or pull events after the fact:
 If you see something you don't want, stop the worker:
 
 ```bash
-/tmp/claude-workers/bin/my-task stop
+/tmp/csd-workers/bin/my-task stop
 ```
 
 ### 5. Stop and clean up
 
 ```bash
-/tmp/claude-workers/bin/my-task stop
+/tmp/csd-workers/bin/my-task stop
 ```
 
 Sends `/exit`, waits up to 10s for `session_end`, kills the tmux session if still running, and removes the meta, events, **and shim** files.
 
 `stop` is destructive: the worker is gone and the shim path stops working. If you wanted the worker around for follow-up turns or a parallel workflow, don't call `stop` until you're done with it. To resume work under the same name, relaunch — `csd launch my-task /path/to/project` again — and you'll get a fresh worker at the same shim path.
 
-After `stop`, the shim no longer exists, so invoking it again surfaces a shell error along the lines of `no such file or directory: /tmp/claude-workers/bin/my-task` (the exact wording depends on your shell). That's expected; the worker is gone.
+After `stop`, the shim no longer exists, so invoking it again surfaces a shell error along the lines of `no such file or directory: /tmp/csd-workers/bin/my-task` (the exact wording depends on your shell). That's expected; the worker is gone.
 
 ### 6. Hand off to a human
 
 ```bash
-/tmp/claude-workers/bin/my-task handoff
+/tmp/csd-workers/bin/my-task handoff
 ```
 
 Prints attach instructions for a human to take over the tmux session.
@@ -169,7 +169,7 @@ csd grant-consent
 <shim> events-file
 ```
 
-`<shim>` is `/tmp/claude-workers/bin/<tmux-name>`. Run `csd help` for the same surface.
+`<shim>` is `/tmp/csd-workers/bin/<tmux-name>`. Run `csd help` for the same surface.
 
 ## Common Patterns
 
@@ -179,26 +179,26 @@ csd grant-consent
 $SKILL/csd launch worker-api ~/proj
 $SKILL/csd launch worker-ui ~/proj
 
-/tmp/claude-workers/bin/worker-api send "Add pagination to /users"
-/tmp/claude-workers/bin/worker-ui send "Add a loading spinner to the user list"
+/tmp/csd-workers/bin/worker-api send "Add pagination to /users"
+/tmp/csd-workers/bin/worker-ui send "Add a loading spinner to the user list"
 
-/tmp/claude-workers/bin/worker-api wait-for-turn 600
-/tmp/claude-workers/bin/worker-ui wait-for-turn 600
+/tmp/csd-workers/bin/worker-api wait-for-turn 600
+/tmp/csd-workers/bin/worker-ui wait-for-turn 600
 
-/tmp/claude-workers/bin/worker-api stop
-/tmp/claude-workers/bin/worker-ui stop
+/tmp/csd-workers/bin/worker-api stop
+/tmp/csd-workers/bin/worker-ui stop
 ```
 
 ### Pipeline: Worker A produces, Worker B consumes
 
 ```bash
 $SKILL/csd launch spec ~/proj
-/tmp/claude-workers/bin/spec converse "Write an OpenAPI spec for /users to /tmp/api.yaml" 300
-/tmp/claude-workers/bin/spec stop
+/tmp/csd-workers/bin/spec converse "Write an OpenAPI spec for /users to /tmp/api.yaml" 300
+/tmp/csd-workers/bin/spec stop
 
 $SKILL/csd launch impl ~/proj
-/tmp/claude-workers/bin/impl converse "Implement the endpoint defined in /tmp/api.yaml" 600
-/tmp/claude-workers/bin/impl stop
+/tmp/csd-workers/bin/impl converse "Implement the endpoint defined in /tmp/api.yaml" 600
+/tmp/csd-workers/bin/impl stop
 ```
 
 ## Edge Cases
@@ -209,11 +209,11 @@ $SKILL/csd launch impl ~/proj
 
 ### Recovering workers after a reboot
 
-Worker runtime state (the `meta`/`events`/`shim` files under `/tmp/claude-workers`) lives in `/tmp`, which macOS clears on reboot — and the tmux panes die with it. But the *conversations* survive: Claude Code persists each session transcript at `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`. `csd adopt` brings one back as a live, driveable worker:
+Worker runtime state (the `meta`/`events`/`shim` files under `/tmp/csd-workers`) lives in `/tmp`, which macOS clears on reboot — and the tmux panes die with it. But the *conversations* survive: Claude Code persists each session transcript at `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`. `csd adopt` brings one back as a live, driveable worker:
 
 ```bash
 $SKILL/csd adopt my-task /path/to/project <session-id>
-# stdout: /tmp/claude-workers/bin/my-task   (same shim contract as launch)
+# stdout: /tmp/csd-workers/bin/my-task   (same shim contract as launch)
 ```
 
 `adopt` pre-writes the meta keyed by `<session-id>`, starts `claude --resume <session-id>` (which preserves the id, so the worker emits events normally), and writes the shim — so the resumed conversation is fully driveable (`converse`/`status`/`read-turn`/…), with all prior context intact. If a tmux session of that name already exists (e.g. restored by [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) / tmux-continuum), `adopt` respawns its pane *in place*, preserving the restored layout; otherwise it opens a new one.
@@ -222,7 +222,7 @@ Find a worker's `<session-id>` from its working directory: the newest `*.jsonl` 
 
 ### Lost the shim path
 
-If you know the tmux name, the path is `/tmp/claude-workers/bin/<tmux-name>`. If you don't, `csd list` enumerates everything; `csd list <pattern>` filters by tmux-name substring.
+If you know the tmux name, the path is `/tmp/csd-workers/bin/<tmux-name>`. If you don't, `csd list` enumerates everything; `csd list <pattern>` filters by tmux-name substring.
 
 ### Long prompts
 
@@ -230,7 +230,7 @@ If you know the tmux name, the path is `/tmp/claude-workers/bin/<tmux-name>`. If
 
 ```bash
 echo "Long instructions..." > /tmp/instructions.txt
-/tmp/claude-workers/bin/my-task send "Read /tmp/instructions.txt and follow it"
+/tmp/csd-workers/bin/my-task send "Read /tmp/instructions.txt and follow it"
 ```
 
 ## Important Notes
@@ -238,6 +238,7 @@ echo "Long instructions..." > /tmp/instructions.txt
 - **One controller per worker.** Two controllers driving the same tmux session will collide.
 - **Workers don't share state with the controller** except via files on disk and the event stream.
 - **Shim paths bake in absolute skill paths.** A plugin reinstall at a new location breaks live workers; relaunch them.
+- **Worker state lives in `/tmp/csd-workers`.** `/tmp/claude-workers` is kept as a best-effort back-compat symlink for shims baked by older versions; relaunch live workers after upgrading.
 
 ## Environment variables
 

--- a/skills/driving-claude-code-sessions/SKILL.md
+++ b/skills/driving-claude-code-sessions/SKILL.md
@@ -1,32 +1,46 @@
 ---
 name: driving-claude-code-sessions
-description: Use when acting as a project manager that delegates tasks to other Claude Code sessions - launch workers, assign them work, monitor progress, review their tool calls, and collect results
+description: Use when acting as a project manager that delegates tasks to other coding-agent sessions (Claude Code, Codex, or Pi) - launch workers, assign them work, monitor progress, review their tool calls, and collect results
 ---
 
-# Driving Claude Code Sessions
+# Driving Coding-Agent Sessions
 
 ## Overview
 
-You can launch other Claude Code sessions as "workers" in tmux, send them prompts, wait for them to finish, read their output, and hand them off to a human. Workers run with `--dangerously-skip-permissions`, so they execute tool calls without prompting. A plugin (claude-session-driver) emits lifecycle events to a JSONL file so the controller can observe what the worker is doing.
+You can launch coding-agent sessions — Claude Code, Codex, or Pi — as "workers" in tmux, send them prompts, wait for them to finish, read their output, and hand them off to a human. Workers run with permissions bypassed, so they execute tool calls without prompting. Each worker emits lifecycle events to a JSONL file so the controller can observe what it's doing — Claude and Codex through their hook systems, Pi through a tailer `csd` runs alongside it.
 
 All operations go through a single CLI: `csd`. After launching a worker, the controller receives a **shim path** at `/tmp/csd-workers/bin/<tmux-name>` that bakes in the worker handle. Every per-worker operation goes through that path — no positional state to thread between calls, no absolute skill path to prepend. A small set of environment variables tune behavior; see [Environment variables](#environment-variables) at the bottom.
 
 The shim path is deterministic: if you pick a memorable tmux name at launch, you can reconstruct `/tmp/csd-workers/bin/<tmux-name>` whenever you need it. For agents driving via tool calls, that's the right model — shell state doesn't persist between calls, so a `SHIM=...; $SHIM cmd` pattern just adds noise. The examples below use the bare path.
 
+## Harnesses
+
+Pick a harness with `--harness` at launch (default `claude`):
+
+```bash
+$SKILL/csd launch --harness codex my-task /path/to/project
+$SKILL/csd launch --harness pi    my-task /path/to/project
+```
+
+Everything after launch is identical across harnesses — `converse`, `read-turn`, `read-events`, `status`, `stop`, and `handoff` all behave the same. Two things differ:
+
+- **Auth.** Each harness authenticates from its own home — Claude `~/.claude`, Codex `~/.codex`, Pi `~/.pi/agent`. `csd` copies that login into the worker at launch, so to rotate credentials, relaunch.
+- **`adopt` is Claude-only.** Claude takes a caller-assigned session id, so a session can be resumed by id. Codex and Pi mint their own ids on the first prompt and offer no resume-by-id — relaunch them instead.
+
 ## Prerequisites
 
 - **tmux**
 - **jq**
-- **claude** CLI
+- a harness CLI — **claude** (default), **codex**, or **pi**
 
 ## Setup
 
 The CLI lives at `<skill>/scripts/csd`. Three top-level subcommands need the skill path:
 
-- `csd launch <tmux-name> <cwd> [-- claude-args...]` — bootstrap a worker
+- `csd launch [--harness <name>] <tmux-name> <cwd> [-- harness-args...]` — bootstrap a worker (harness defaults to `claude`)
 - `csd adopt <tmux-name> <cwd> <session-id> [-- claude-args...]` — re-adopt an existing Claude session as a worker (see [Recovering workers](#recovering-workers-after-a-reboot))
 - `csd list [--all]` — enumerate workers
-- `csd grant-consent` — one-time consent for `--dangerously-skip-permissions`
+- `csd grant-consent` — one-time consent to run workers with permissions bypassed
 
 Once a worker is launched, run subsequent commands against `/tmp/csd-workers/bin/<tmux-name>`:
 
@@ -52,15 +66,16 @@ $SKILL/csd launch my-task /path/to/project
 ```
 
 `csd launch`:
-- Writes a meta file and a 3-line shim at `/tmp/csd-workers/bin/my-task`
-- Starts tmux + claude with the plugin loaded
-- Waits up to 30s for `session_start`
+- Writes a 3-line shim at `/tmp/csd-workers/bin/my-task`
+- Starts tmux and the harness in it
+- Blocks until the worker is ready — Claude waits for `session_start`; Codex and Pi settle, then reconfirm on the first send
 - Prints the shim path on stdout (one line)
 - Prints a "Worker launched" panel on stderr — the `reproduce:` line is the exact command to relaunch with the same args
 
-Pass claude CLI args after a `--` separator:
+Pass harness CLI args after a `--` separator, or pick a non-default harness with `--harness`:
 ```bash
 $SKILL/csd launch my-task /path/to/project -- --model sonnet
+$SKILL/csd launch --harness codex my-task /path/to/project
 ```
 
 ### 2. Converse (the typical case)
@@ -113,7 +128,7 @@ Or pull events after the fact:
 /tmp/csd-workers/bin/my-task read-events --type pre_tool_use
 ```
 
-`--type` accepts one of: `session_start`, `user_prompt_submit`, `pre_tool_use`, `stop`, `session_end`. Unknown event names fail fast.
+`--type` accepts one of: `session_start`, `user_prompt_submit`, `pre_tool_use`, `post_tool_use`, `stop`, `session_end`. Unknown event names fail fast. (`post_tool_use` comes from Codex and Pi workers, not Claude.)
 
 If you see something you don't want, stop the worker:
 
@@ -127,7 +142,7 @@ If you see something you don't want, stop the worker:
 /tmp/csd-workers/bin/my-task stop
 ```
 
-Sends `/exit`, waits up to 10s for `session_end`, kills the tmux session if still running, and removes the meta, events, **and shim** files.
+Sends the worker's quit command, waits up to 10s for `session_end`, kills the tmux session if still running, and removes the meta, events, **and shim** files.
 
 `stop` is destructive: the worker is gone and the shim path stops working. If you wanted the worker around for follow-up turns or a parallel workflow, don't call `stop` until you're done with it. To resume work under the same name, relaunch — `csd launch my-task /path/to/project` again — and you'll get a fresh worker at the same shim path.
 
@@ -152,8 +167,8 @@ $SKILL/csd list api                  # substring filter on tmux name
 ## Reference
 
 ```
-csd launch <tmux-name> <cwd> [-- claude-args...]
-csd adopt <tmux-name> <cwd> <session-id> [-- claude-args...]
+csd launch [--harness <name>] <tmux-name> <cwd> [-- harness-args...]
+csd adopt <tmux-name> <cwd> <session-id> [-- claude-args...]    # claude only
 csd list [--all] [<pattern>]
 csd grant-consent
 
@@ -216,7 +231,7 @@ $SKILL/csd adopt my-task /path/to/project <session-id>
 # stdout: /tmp/csd-workers/bin/my-task   (same shim contract as launch)
 ```
 
-`adopt` pre-writes the meta keyed by `<session-id>`, starts `claude --resume <session-id>` (which preserves the id, so the worker emits events normally), and writes the shim — so the resumed conversation is fully driveable (`converse`/`status`/`read-turn`/…), with all prior context intact. If a tmux session of that name already exists (e.g. restored by [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) / tmux-continuum), `adopt` respawns its pane *in place*, preserving the restored layout; otherwise it opens a new one.
+`adopt` pre-writes the meta keyed by `<session-id>`, starts `claude --resume <session-id>` (which preserves the id, so the worker emits events normally), and writes the shim — so the resumed conversation is fully driveable (`converse`/`status`/`read-turn`/…), with all prior context intact. If a tmux session of that name already exists (e.g. restored by [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) / tmux-continuum), `adopt` respawns its pane *in place*, preserving the restored layout; otherwise it opens a new one. Because `adopt` resumes by session id, it is Claude-only — Codex and Pi mint their own ids and offer no resume-by-id, so relaunch those instead.
 
 Find a worker's `<session-id>` from its working directory: the newest `*.jsonl` in `~/.claude/projects/<cwd with every / . _ replaced by ->`. For bulk recovery (e.g. pairing with tmux-continuum's `@continuum-boot`), `examples/recover-workers.sh` reads a tmux-resurrect snapshot, derives each id, and calls `adopt` per worker — run it with `--dry-run` first. Note: workers are restored as resumed sessions, not their original tool/MCP state; re-pass any launch args (e.g. `-- --model …`) you depended on.
 
@@ -247,7 +262,10 @@ The `csd` CLI honors a small set of env vars. All are optional.
 | Variable | Purpose |
 |---|---|
 | `CSD_CLAUDE_BIN` | Path to the `claude` binary. Defaults to `claude` (resolved via `PATH`). Set when claude is not on `PATH` or you want to pin a specific version. |
+| `CSD_CODEX_BIN`, `CSD_PI_BIN` | The same, for the `codex` and `pi` binaries when driving those harnesses. |
+| `CSD_CODEX_MODEL`, `CSD_PI_MODEL` | Model to launch a Codex or Pi worker with. Defaults: `gpt-5.5` (codex), `openai-codex/gpt-5.5` (pi). |
+| `CSD_WORKER_DIR` | Worker state directory. Defaults to `/tmp/csd-workers`. |
 | `CSD_CONVERSE_DIAG_FILE` | When set, `csd converse` writes a post-mortem diagnostic on timeout — `ps` tree, `tmux capture-pane`, last 30 lines of the claude session JSONL, last 20 lines of the csd events JSONL — to this path, then emits a `csd-diagnostic: <path>` pointer to stderr. The file is overwritten on each timeout. Unset = no diagnostic file. Useful when wrapping csd in a harness that can ship the file off-box before the worker is reaped. |
-| `HOME` | Used to locate `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` and the one-time consent file (`~/.claude/.claude-session-driver-consent`). |
+| `HOME` | Locates the Claude transcript (`~/.claude/projects/<encoded-cwd>/<sid>.jsonl`), the consent file (`~/.claude/.claude-session-driver-consent`), and the per-harness auth staged at launch (`~/.codex`, `~/.pi/agent`). Codex and Pi record their own transcript path in the worker meta. |
 
 The same list is shown by `csd help`.

--- a/skills/driving-claude-code-sessions/scripts/_lib.sh
+++ b/skills/driving-claude-code-sessions/scripts/_lib.sh
@@ -29,7 +29,7 @@ _CSD_WORKER_DIR="${CSD_WORKER_DIR:-/tmp/csd-workers}"
 
 # Event types emitted by the emit-event hook. Keep in sync with the case
 # statement in hooks/emit-event.
-_CSD_VALID_EVENTS="session_start user_prompt_submit pre_tool_use stop session_end"
+_CSD_VALID_EVENTS="session_start user_prompt_submit pre_tool_use post_tool_use stop session_end"
 
 validate_event_type() {
   local arg="$1"

--- a/skills/driving-claude-code-sessions/scripts/_lib.sh
+++ b/skills/driving-claude-code-sessions/scripts/_lib.sh
@@ -9,6 +9,22 @@
 #                           non-zero with a message to stderr if neither
 #                           matches a known worker.
 
+# Absolute path to scripts/ (this file's dir). Used to locate drivers/.
+_CSD_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source the harness driver for <harness> (default claude). Drivers live at
+# scripts/drivers/<harness>.sh and define the harness slot functions.
+_load_driver() {
+  local harness="${1:-claude}"
+  local driver_file="$_CSD_SCRIPT_DIR/drivers/${harness}.sh"
+  if [ ! -f "$driver_file" ]; then
+    echo "Error: no driver for harness '$harness' (expected $driver_file)" >&2
+    return 1
+  fi
+  # shellcheck source=/dev/null
+  source "$driver_file"
+}
+
 _CSD_WORKER_DIR=/tmp/claude-workers
 
 # Event types emitted by the emit-event hook. Keep in sync with the case

--- a/skills/driving-claude-code-sessions/scripts/_lib.sh
+++ b/skills/driving-claude-code-sessions/scripts/_lib.sh
@@ -25,7 +25,7 @@ _load_driver() {
   source "$driver_file"
 }
 
-_CSD_WORKER_DIR=/tmp/claude-workers
+_CSD_WORKER_DIR="${CSD_WORKER_DIR:-/tmp/csd-workers}"
 
 # Event types emitted by the emit-event hook. Keep in sync with the case
 # statement in hooks/emit-event.

--- a/skills/driving-claude-code-sessions/scripts/_lib.sh
+++ b/skills/driving-claude-code-sessions/scripts/_lib.sh
@@ -67,3 +67,17 @@ resolve_session() {
   fi
   echo "$found"
 }
+
+# Print the tmux session name for <worker>, working even before a derive worker
+# has self-registered (falls back to <worker> when it names a live tmux session —
+# the shim sets --worker to the tmux_name).
+_worker_tmux_name() {
+  local worker="$1" sid tn
+  sid=$(resolve_session "$worker" 2>/dev/null) || sid=""
+  if [ -n "$sid" ] && [ -f "$_CSD_WORKER_DIR/${sid}.meta" ]; then
+    tn=$(jq -r '.tmux_name' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null)
+    [ -n "$tn" ] && [ "$tn" != "null" ] && { echo "$tn"; return 0; }
+  fi
+  if tmux has-session -t "$worker" 2>/dev/null; then echo "$worker"; return 0; fi
+  echo "$worker"
+}

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -323,22 +323,35 @@ cmd_converse() {
   local prompt="${1:?Usage: converse [--with-turn] <prompt> [timeout=120]}"
   local timeout="${2:-120}"
 
-  local sid cwd encoded log_file event_file
-  sid=$(resolve_session "$WORKER")
-  cwd=$(jq -r '.cwd' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null)
-  if [ -z "$cwd" ] || [ "$cwd" = "null" ]; then
-    echo "Error: Could not determine working directory from meta file" >&2
-    return 1
-  fi
-  log_file=$(harness_transcript_path "$sid" "$cwd")
-  event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
+  local strategy sid cwd log_file event_file before_count=0 after_line=0
+  strategy=$(harness_id_strategy)
 
-  local before_count after_line
-  before_count=$(harness_count_text "$log_file")
-  after_line=0
-  [ -f "$event_file" ] && after_line=$(wc -l < "$event_file" | tr -d ' ')
+  if [ "$strategy" = "assign" ]; then
+    sid=$(resolve_session "$WORKER")
+    cwd=$(jq -r '.cwd' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null)
+    if [ -z "$cwd" ] || [ "$cwd" = "null" ]; then
+      echo "Error: Could not determine working directory from meta file" >&2
+      return 1
+    fi
+    log_file=$(harness_transcript_path "$sid" "$cwd")
+    event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
+    before_count=$(harness_count_text "$log_file")
+    [ -f "$event_file" ] && after_line=$(wc -l < "$event_file" | tr -d ' ')
+  fi
 
   cmd_send "$prompt"
+
+  if [ "$strategy" = "derive" ]; then
+    # The first prompt self-registered the worker; resolve it now.
+    sid=$(resolve_session "$WORKER" 2>/dev/null) || sid=""
+    if [ -z "$sid" ]; then
+      echo "Error: worker did not register a session after the prompt" >&2
+      return 1
+    fi
+    cwd=$(jq -r '.cwd' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null)
+    log_file=$(harness_transcript_path "$sid" "$cwd")
+    event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
+  fi
 
   if ! cmd_wait_for_turn "$timeout" --after-line "$after_line" >/dev/null; then
     echo "Error: Worker did not finish within ${timeout}s" >&2
@@ -392,18 +405,22 @@ _prompt_submitted_since() {
 
 cmd_send() {
   local prompt="${1:?Usage: send <prompt-text>}"
-  local sid tmux_name
-  sid=$(resolve_session "$WORKER")
-  tmux_name=$(jq -r '.tmux_name' "$_CSD_WORKER_DIR/${sid}.meta")
+  local tmux_name
+  tmux_name=$(_worker_tmux_name "$WORKER")
 
   if ! tmux has-session -t "$tmux_name" 2>/dev/null; then
     echo "Error: tmux session '$tmux_name' does not exist" >&2
     return 1
   fi
 
-  local event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
-  local before_line=0
-  [ -f "$event_file" ] && before_line=$(wc -l < "$event_file" | tr -d ' ')
+  # assign workers have an events file already; derive workers register it on
+  # this prompt's first lifecycle event. Capture a baseline if a sid resolves now.
+  local sid event_file="" before_line=0
+  sid=$(resolve_session "$WORKER" 2>/dev/null) || sid=""
+  if [ -n "$sid" ]; then
+    event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
+    [ -f "$event_file" ] && before_line=$(wc -l < "$event_file" | tr -d ' ')
+  fi
 
   local ESC PASTE_START PASTE_END SAFE
   ESC=$'\x1b'
@@ -425,7 +442,16 @@ cmd_send() {
   local retry_interval="${CSD_SUBMIT_RETRY_INTERVAL:-2}"
   local waited=0 since_enter=0
   tmux send-keys -t "$tmux_name" Enter
-  while ! _prompt_submitted_since "$event_file" "$before_line"; do
+  while :; do
+    # derive: the producer self-registers the meta on the first event — resolve
+    # the sid + events file once it appears, then confirm against it.
+    if [ -z "$event_file" ]; then
+      sid=$(resolve_session "$WORKER" 2>/dev/null) || sid=""
+      [ -n "$sid" ] && event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
+    fi
+    if [ -n "$event_file" ] && _prompt_submitted_since "$event_file" "$before_line"; then
+      break
+    fi
     if awk "BEGIN{exit !($waited >= $submit_timeout)}"; then
       echo "Error: prompt pasted but worker did not confirm submission within ${submit_timeout}s (issue #20). The tmux session may be slow to accept the paste; raise CSD_SUBMIT_TIMEOUT to allow more time." >&2
       return 1

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -987,6 +987,17 @@ fi
 
 shift  # consume the subcommand name
 
+# Load the harness driver before dispatching. Per-worker subs read the harness
+# from the worker meta (default claude); launch/adopt default to claude here
+# (the --harness flag + per-command override is added in a later task).
+if is_in "$SUB" "${PER_WORKER_SUBS[@]}"; then
+  _wsid=$(resolve_session "$WORKER") || exit 1
+  _whar=$(jq -r '.harness // "claude"' "/tmp/claude-workers/${_wsid}.meta" 2>/dev/null)
+  _load_driver "${_whar:-claude}"
+elif [ "$SUB" = "launch" ] || [ "$SUB" = "adopt" ]; then
+  _load_driver claude
+fi
+
 case "$SUB" in
   help)            usage ;;
   grant-consent)   cmd_grant_consent ;;

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -9,7 +9,7 @@ set -euo pipefail
 #   status, read-events, read-turn, stop, handoff, session-id, events-file
 #
 # Per-worker subcommands are normally invoked through a shim at
-# /tmp/claude-workers/bin/<tmux-name> that bakes in --worker. Direct
+# $_CSD_WORKER_DIR/bin/<tmux-name> that bakes in --worker. Direct
 # invocation as `csd --worker <name> <sub>` is also supported.
 
 CSD_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
@@ -31,7 +31,7 @@ Usage: csd <subcommand> [args...]
 
 A worker is a Claude Code session in a tmux pane with the session-driver plugin
 loaded. \`csd launch\` prints a *shim path* on stdout (deterministic at
-/tmp/claude-workers/bin/<tmux-name>) — run that shim for all per-worker
+$_CSD_WORKER_DIR/bin/<tmux-name>) — run that shim for all per-worker
 subcommands. \`csd stop\` removes the shim along with the worker's state.
 
 Top-level subcommands:
@@ -40,7 +40,7 @@ Top-level subcommands:
   adopt <tmux-name> <cwd> <session-id> [-- claude-args...]
                        Re-adopt an existing Claude session as a driveable
                        worker via \`claude --resume <session-id>\`. Restores a
-                       worker after a reboot/crash wiped /tmp/claude-workers
+                       worker after a reboot/crash wiped $_CSD_WORKER_DIR
                        while the conversation transcript survived. If a tmux
                        session named <tmux-name> already exists (e.g. restored
                        by tmux-resurrect), respawns its pane in place; else
@@ -118,7 +118,7 @@ _dump_converse_diag() {
   mkdir -p "$(dirname "$dest")" 2>/dev/null || return 1
   # The user-facing $worker may be an alias; the real tmux session name lives in the meta.
   local tmux_name=""
-  tmux_name=$(jq -r '.tmux_name // empty' "/tmp/claude-workers/${sid}.meta" 2>/dev/null || true)
+  tmux_name=$(jq -r '.tmux_name // empty' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null || true)
   [ -z "$tmux_name" ] && tmux_name="$worker"
   {
     echo "=== csd converse diagnostic ($(date -u +%Y-%m-%dT%H:%M:%SZ)) ==="
@@ -187,14 +187,14 @@ cmd_session_id() {
 cmd_events_file() {
   local sid
   sid=$(resolve_session "$WORKER")
-  echo "/tmp/claude-workers/${sid}.events.jsonl"
+  echo "$_CSD_WORKER_DIR/${sid}.events.jsonl"
 }
 
 cmd_status() {
   local sid tmux_name
   sid=$(resolve_session "$WORKER")
-  tmux_name=$(jq -r '.tmux_name' "/tmp/claude-workers/${sid}.meta")
-  _worker_status "$tmux_name" "/tmp/claude-workers/${sid}.events.jsonl"
+  tmux_name=$(jq -r '.tmux_name' "$_CSD_WORKER_DIR/${sid}.meta")
+  _worker_status "$tmux_name" "$_CSD_WORKER_DIR/${sid}.events.jsonl"
 }
 
 cmd_read_events() {
@@ -213,7 +213,7 @@ cmd_read_events() {
 
   local sid event_file
   sid=$(resolve_session "$WORKER")
-  event_file="/tmp/claude-workers/${sid}.events.jsonl"
+  event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
   if [ ! -f "$event_file" ]; then
     echo "Error: No event file for session $sid" >&2
     return 1
@@ -255,7 +255,7 @@ cmd_wait_for_turn() {
 
   local sid event_file
   sid=$(resolve_session "$WORKER")
-  event_file="/tmp/claude-workers/${sid}.events.jsonl"
+  event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
   local deadline=$((SECONDS + timeout))
 
   while [ ! -f "$event_file" ]; do
@@ -297,7 +297,7 @@ cmd_read_turn() {
 
   local sid cwd encoded log_file last_prompt_line
   sid=$(resolve_session "$WORKER")
-  cwd=$(jq -r '.cwd' "/tmp/claude-workers/${sid}.meta" 2>/dev/null)
+  cwd=$(jq -r '.cwd' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null)
   if [ -z "$cwd" ] || [ "$cwd" = "null" ]; then
     echo "Error: Could not determine working directory from meta file" >&2
     return 1
@@ -367,7 +367,7 @@ cmd_converse() {
 
   local sid cwd encoded log_file event_file
   sid=$(resolve_session "$WORKER")
-  cwd=$(jq -r '.cwd' "/tmp/claude-workers/${sid}.meta" 2>/dev/null)
+  cwd=$(jq -r '.cwd' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null)
   if [ -z "$cwd" ] || [ "$cwd" = "null" ]; then
     echo "Error: Could not determine working directory from meta file" >&2
     return 1
@@ -377,7 +377,7 @@ cmd_converse() {
   fi
   encoded="${cwd//\//-}"
   log_file="$HOME/.claude/projects/${encoded}/${sid}.jsonl"
-  event_file="/tmp/claude-workers/${sid}.events.jsonl"
+  event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
 
   count_text_messages() {
     if [ ! -f "$log_file" ]; then echo 0; return; fi
@@ -452,14 +452,14 @@ cmd_send() {
   local prompt="${1:?Usage: send <prompt-text>}"
   local sid tmux_name
   sid=$(resolve_session "$WORKER")
-  tmux_name=$(jq -r '.tmux_name' "/tmp/claude-workers/${sid}.meta")
+  tmux_name=$(jq -r '.tmux_name' "$_CSD_WORKER_DIR/${sid}.meta")
 
   if ! tmux has-session -t "$tmux_name" 2>/dev/null; then
     echo "Error: tmux session '$tmux_name' does not exist" >&2
     return 1
   fi
 
-  local event_file="/tmp/claude-workers/${sid}.events.jsonl"
+  local event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
   local before_line=0
   [ -f "$event_file" ] && before_line=$(wc -l < "$event_file" | tr -d ' ')
 
@@ -501,14 +501,14 @@ cmd_send() {
 cmd_stop() {
   local sid tmux_name
   sid=$(resolve_session "$WORKER")
-  tmux_name=$(jq -r '.tmux_name' "/tmp/claude-workers/${sid}.meta")
+  tmux_name=$(jq -r '.tmux_name' "$_CSD_WORKER_DIR/${sid}.meta")
 
   if tmux has-session -t "$tmux_name" 2>/dev/null; then
     tmux send-keys -t "$tmux_name" -l '/exit'
     tmux send-keys -t "$tmux_name" Enter
 
     # Wait up to 10s for session_end
-    local event_file="/tmp/claude-workers/${sid}.events.jsonl"
+    local event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
     local deadline=$((SECONDS + 10))
     while [ "$SECONDS" -lt "$deadline" ]; do
       if [ -f "$event_file" ] && grep -q '"event":"session_end"' "$event_file"; then
@@ -523,9 +523,9 @@ cmd_stop() {
     fi
   fi
 
-  rm -f "/tmp/claude-workers/${sid}.events.jsonl"
-  rm -f "/tmp/claude-workers/${sid}.meta"
-  rm -f "/tmp/claude-workers/bin/${tmux_name}"
+  rm -f "$_CSD_WORKER_DIR/${sid}.events.jsonl"
+  rm -f "$_CSD_WORKER_DIR/${sid}.meta"
+  rm -f "$_CSD_WORKER_DIR/bin/${tmux_name}"
 
   echo "Worker $tmux_name ($sid) stopped. Shim removed."
 }
@@ -533,7 +533,7 @@ cmd_stop() {
 cmd_handoff() {
   local sid tmux_name
   sid=$(resolve_session "$WORKER")
-  tmux_name=$(jq -r '.tmux_name' "/tmp/claude-workers/${sid}.meta")
+  tmux_name=$(jq -r '.tmux_name' "$_CSD_WORKER_DIR/${sid}.meta")
   cat <<EOF
 The worker is running in tmux session '$tmux_name'. To take over:
 
@@ -556,7 +556,7 @@ EOF
 # Shared by cmd_launch and cmd_adopt.
 _await_session_start() {
   local tmux_name="$1" session_id="$2"
-  local event_file="/tmp/claude-workers/${session_id}.events.jsonl"
+  local event_file="$_CSD_WORKER_DIR/${session_id}.events.jsonl"
 
   # Trust-dialog accept (content-aware) — same logic as legacy launch-worker.sh
   local trust_deadline=$((SECONDS + 5))
@@ -596,7 +596,7 @@ _await_session_start() {
     fi
   } >&2
   tmux kill-session -t "$tmux_name" 2>/dev/null || true
-  rm -f "/tmp/claude-workers/${session_id}.meta" "$event_file"
+  rm -f "$_CSD_WORKER_DIR/${session_id}.meta" "$event_file"
   return 1
 }
 
@@ -605,7 +605,7 @@ _await_session_start() {
 # Shared by cmd_launch and cmd_adopt.
 _write_worker_shim() {
   local tmux_name="$1"
-  local shim_path="/tmp/claude-workers/bin/$tmux_name"
+  local shim_path="$_CSD_WORKER_DIR/bin/$tmux_name"
   cat > "$shim_path" <<EOF
 #!/bin/bash
 exec "$CSD_PATH" --worker "$tmux_name" "\$@"
@@ -729,7 +729,7 @@ EOF
   local session_id
   session_id=$(uuidgen | tr '[:upper:]' '[:lower:]')
 
-  mkdir -p /tmp/claude-workers /tmp/claude-workers/bin
+  mkdir -p $_CSD_WORKER_DIR $_CSD_WORKER_DIR/bin
 
   # Write meta (includes cwd and invocation for reproduce)
   local invocation_json
@@ -741,12 +741,12 @@ EOF
     --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
     --argjson invocation "$invocation_json" \
     '{tmux_name: $tmux_name, session_id: $session_id, cwd: $cwd, started_at: $started_at, invocation: $invocation}' \
-    > "/tmp/claude-workers/${session_id}.meta"
+    > "$_CSD_WORKER_DIR/${session_id}.meta"
 
   # Collision check
   if tmux has-session -t "$tmux_name" 2>/dev/null; then
     echo "Error: tmux session '$tmux_name' already exists" >&2
-    rm -f "/tmp/claude-workers/${session_id}.meta"
+    rm -f "$_CSD_WORKER_DIR/${session_id}.meta"
     return 1
   fi
 
@@ -765,7 +765,7 @@ EOF
   # Accept any trust dialog and block until the worker emits session_start.
   _await_session_start "$tmux_name" "$session_id" || return 1
 
-  local event_file="/tmp/claude-workers/${session_id}.events.jsonl"
+  local event_file="$_CSD_WORKER_DIR/${session_id}.events.jsonl"
   local shim_path
   shim_path="$(_write_worker_shim "$tmux_name")"
 
@@ -831,7 +831,7 @@ EOF
     return 1
   fi
 
-  mkdir -p /tmp/claude-workers /tmp/claude-workers/bin
+  mkdir -p $_CSD_WORKER_DIR $_CSD_WORKER_DIR/bin
 
   # `claude --resume <id>` preserves the session id, so the worker's runtime
   # session_id equals the id we were handed. Pre-write the meta keyed by it
@@ -846,7 +846,7 @@ EOF
     --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
     --argjson invocation "$invocation_json" \
     '{tmux_name: $tmux_name, session_id: $session_id, cwd: $cwd, started_at: $started_at, invocation: $invocation}' \
-    > "/tmp/claude-workers/${session_id}.meta"
+    > "$_CSD_WORKER_DIR/${session_id}.meta"
 
   # Start (or respawn) the worker with --resume instead of --session-id.
   local claude_bin="${CSD_CLAUDE_BIN:-claude}"
@@ -879,7 +879,7 @@ EOF
   # Accept any trust dialog and block until the worker emits session_start.
   _await_session_start "$tmux_name" "$session_id" || return 1
 
-  local event_file="/tmp/claude-workers/${session_id}.events.jsonl"
+  local event_file="$_CSD_WORKER_DIR/${session_id}.events.jsonl"
   local shim_path
   shim_path="$(_write_worker_shim "$tmux_name")"
 
@@ -917,7 +917,7 @@ cmd_list() {
     esac
   done
 
-  local worker_dir=/tmp/claude-workers
+  local worker_dir=$_CSD_WORKER_DIR
   shopt -s nullglob
   local metas=("$worker_dir"/*.meta)
   shopt -u nullglob
@@ -992,7 +992,7 @@ shift  # consume the subcommand name
 # (the --harness flag + per-command override is added in a later task).
 if is_in "$SUB" "${PER_WORKER_SUBS[@]}"; then
   _wsid=$(resolve_session "$WORKER") || exit 1
-  _whar=$(jq -r '.harness // "claude"' "/tmp/claude-workers/${_wsid}.meta" 2>/dev/null)
+  _whar=$(jq -r '.harness // "claude"' "$_CSD_WORKER_DIR/${_wsid}.meta" 2>/dev/null)
   _load_driver "${_whar:-claude}"
 elif [ "$SUB" = "launch" ] || [ "$SUB" = "adopt" ]; then
   _load_driver claude

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -602,6 +602,12 @@ EOF
   session_id=$(uuidgen | tr '[:upper:]' '[:lower:]')
 
   mkdir -p $_CSD_WORKER_DIR $_CSD_WORKER_DIR/bin
+  # Best-effort back-compat: only symlink the legacy path when it doesn't already
+  # exist (a leftover real /tmp/claude-workers dir from older csd is left alone;
+  # relaunch any live pre-upgrade workers after this upgrade).
+  if [ "$_CSD_WORKER_DIR" = "/tmp/csd-workers" ] && [ ! -e /tmp/claude-workers ]; then
+    ln -s /tmp/csd-workers /tmp/claude-workers 2>/dev/null || true
+  fi
 
   # Write meta (includes cwd and invocation for reproduce)
   local invocation_json
@@ -709,6 +715,12 @@ EOF
   fi
 
   mkdir -p $_CSD_WORKER_DIR $_CSD_WORKER_DIR/bin
+  # Best-effort back-compat: only symlink the legacy path when it doesn't already
+  # exist (a leftover real /tmp/claude-workers dir from older csd is left alone;
+  # relaunch any live pre-upgrade workers after this upgrade).
+  if [ "$_CSD_WORKER_DIR" = "/tmp/csd-workers" ] && [ ! -e /tmp/claude-workers ]; then
+    ln -s /tmp/csd-workers /tmp/claude-workers 2>/dev/null || true
+  fi
 
   # `claude --resume <id>` preserves the session id, so the worker's runtime
   # session_id equals the id we were handed. Pre-write the meta keyed by it

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -906,6 +906,17 @@ cmd_list() {
 
 # --- main: arg parsing, validation, dispatch ---
 
+# Internal subcommand: `csd poll <harness> <session_dir> <worker_dir> <tmux_name>`
+# runs the harness's transcript tailer (the control-plane producer for poll
+# harnesses like pi). The spine starts this in a tmux window; not user-facing.
+if [ "${1:-}" = "poll" ]; then
+  shift
+  _phar="${1:?Usage: csd poll <harness> <session_dir> <worker_dir> <tmux_name>}"; shift
+  _load_driver "$_phar"
+  harness_poll "$@"
+  exit $?
+fi
+
 # Parse --worker (top-level flag, before subcommand)
 WORKER=""
 while [ $# -gt 0 ]; do

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -468,6 +468,8 @@ cmd_stop() {
   rm -f "$_CSD_WORKER_DIR/${sid}.events.jsonl"
   rm -f "$_CSD_WORKER_DIR/${sid}.meta"
   rm -f "$_CSD_WORKER_DIR/bin/${tmux_name}"
+  rm -f "$_CSD_WORKER_DIR/${tmux_name}.harness"
+  rm -rf "$_CSD_WORKER_DIR/homes/${tmux_name}"
 
   echo "Worker $tmux_name ($sid) stopped. Shim removed."
 }
@@ -597,9 +599,14 @@ EOF
     return 1
   fi
 
-  # Generate session ID
-  local session_id
-  session_id=$(uuidgen | tr '[:upper:]' '[:lower:]')
+  export CSD_PLUGIN_DIR="$plugin_dir"
+  local worker_home="$_CSD_WORKER_DIR/homes/$tmux_name"
+  _CSD_CURRENT_WORKER_HOME="$worker_home"
+
+  # Generate the session id only for assign-id harnesses; derive harnesses learn
+  # it from their first lifecycle event (the producer self-registers the meta).
+  local session_id=""
+  [ "$(harness_id_strategy)" = "assign" ] && session_id=$(uuidgen | tr '[:upper:]' '[:lower:]')
 
   mkdir -p $_CSD_WORKER_DIR $_CSD_WORKER_DIR/bin
   # Best-effort back-compat: only symlink the legacy path when it doesn't already
@@ -609,30 +616,41 @@ EOF
     ln -s /tmp/csd-workers /tmp/claude-workers 2>/dev/null || true
   fi
 
-  # Write meta (includes cwd and invocation for reproduce)
+  # Sidecar harness marker so per-worker commands can load the right driver during
+  # the derive pre-registration window (before the producer self-registers meta).
+  printf '%s' "$harness" > "$_CSD_WORKER_DIR/${tmux_name}.harness"
+
+  # assign: pre-write the meta keyed by the chosen session id. derive: the
+  # control-plane producer self-registers it on the first prompt.
   local invocation_json
   invocation_json=$(printf '%s\n' "${original_argv[@]}" | jq -R . | jq -s .)
-  jq -n \
-    --arg tmux_name "$tmux_name" \
-    --arg session_id "$session_id" \
-    --arg cwd "$working_dir" \
-    --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-    --arg harness "$harness" \
-    --argjson invocation "$invocation_json" \
-    '{tmux_name: $tmux_name, session_id: $session_id, cwd: $cwd, started_at: $started_at, harness: $harness, invocation: $invocation}' \
-    > "$_CSD_WORKER_DIR/${session_id}.meta"
+  if [ "$(harness_id_strategy)" = "assign" ]; then
+    jq -n \
+      --arg tmux_name "$tmux_name" \
+      --arg session_id "$session_id" \
+      --arg cwd "$working_dir" \
+      --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+      --arg harness "$harness" \
+      --argjson invocation "$invocation_json" \
+      '{tmux_name: $tmux_name, session_id: $session_id, cwd: $cwd, started_at: $started_at, harness: $harness, invocation: $invocation}' \
+      > "$_CSD_WORKER_DIR/${session_id}.meta"
+  fi
 
   # Collision check
   if tmux has-session -t "$tmux_name" 2>/dev/null; then
     echo "Error: tmux session '$tmux_name' already exists" >&2
-    rm -f "$_CSD_WORKER_DIR/${session_id}.meta"
+    [ -n "$session_id" ] && rm -f "$_CSD_WORKER_DIR/${session_id}.meta"
+    rm -f "$_CSD_WORKER_DIR/${tmux_name}.harness"
     return 1
   fi
+
+  # Per-worker harness setup (codex: CODEX_HOME config + staged auth; claude: no-op).
+  harness_prepare "$tmux_name" "$working_dir" "$worker_home"
 
   # Build the harness launch argv (per-harness flags), then start tmux.
   local launch_argv=()
   while IFS= read -r _tok; do launch_argv+=("$_tok"); done \
-    < <(harness_launch_argv launch "$session_id" "$working_dir" "$plugin_dir" "")
+    < <(harness_launch_argv launch "$session_id" "$working_dir" "$plugin_dir" "$worker_home")
   local WORKER_ENV_ARGS=()
   harness_env_args
   tmux new-session -d -s "$tmux_name" -c "$working_dir" \
@@ -640,10 +658,14 @@ EOF
     "${launch_argv[@]}" \
     "${extra_args[@]+"${extra_args[@]}"}"
 
-  # Accept any trust dialog and block until the worker emits session_start.
-  _await_session_start "$tmux_name" "$session_id" || return 1
+  # Post-launch gate dismissal (codex: trust menu); then become ready.
+  harness_post_launch "$tmux_name"
+  if [ "$(harness_id_strategy)" = "assign" ]; then
+    _await_session_start "$tmux_name" "$session_id" || return 1
+  else
+    harness_await_ready "$tmux_name" ""
+  fi
 
-  local event_file="$_CSD_WORKER_DIR/${session_id}.events.jsonl"
   local shim_path
   shim_path="$(_write_worker_shim "$tmux_name")"
 
@@ -659,9 +681,13 @@ EOF
   {
     echo "Worker launched."
     echo "  tmux:       $tmux_name"
-    echo "  session_id: $session_id"
+    echo "  session_id: ${session_id:-(derive — assigned on first prompt)}"
     echo "  cwd:        $working_dir"
-    echo "  events:     $event_file"
+    if [ -n "$session_id" ]; then
+      echo "  events:     $_CSD_WORKER_DIR/${session_id}.events.jsonl"
+    else
+      echo "  events:     (registered on first prompt)"
+    fi
     echo "  reproduce: $(printf '%q' "$CSD_PATH") launch${reproduce_args}"
   } >&2
 }
@@ -672,6 +698,10 @@ cmd_adopt() {
     if [ "$1" = "--harness" ]; then harness="$2"; shift 2; else harness="${1#--harness=}"; shift; fi
   done
   _load_driver "$harness"
+  if [ "$(harness_id_strategy)" != "assign" ]; then
+    echo "Error: adopt supports only assign-id harnesses (claude); got '$harness'" >&2
+    return 1
+  fi
   local tmux_name="${1:?Usage: adopt [--harness <name>] <tmux-name> <cwd> <session-id> [-- claude-args...]}"
   local working_dir="${2:?Usage: adopt <tmux-name> <cwd> <session-id> [-- claude-args...]}"
   local session_id="${3:?Usage: adopt <tmux-name> <cwd> <session-id> [-- claude-args...]}"
@@ -875,8 +905,15 @@ shift  # consume the subcommand name
 # from the worker meta (default claude); launch/adopt default to claude here
 # (the --harness flag + per-command override is added in a later task).
 if is_in "$SUB" "${PER_WORKER_SUBS[@]}"; then
-  _wsid=$(resolve_session "$WORKER") || exit 1
-  _whar=$(jq -r '.harness // "claude"' "$_CSD_WORKER_DIR/${_wsid}.meta" 2>/dev/null)
+  _wsid=$(resolve_session "$WORKER" 2>/dev/null) || _wsid=""
+  if [ -n "$_wsid" ] && [ -f "$_CSD_WORKER_DIR/${_wsid}.meta" ]; then
+    _whar=$(jq -r '.harness // "claude"' "$_CSD_WORKER_DIR/${_wsid}.meta" 2>/dev/null)
+  elif [ -f "$_CSD_WORKER_DIR/${WORKER}.harness" ]; then
+    # derive pre-registration window: meta not self-registered yet.
+    _whar=$(cat "$_CSD_WORKER_DIR/${WORKER}.harness")
+  else
+    echo "Error: no worker known as '$WORKER'" >&2; exit 1
+  fi
   _load_driver "${_whar:-claude}"
 elif [ "$SUB" = "launch" ] || [ "$SUB" = "adopt" ]; then
   _load_driver claude

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -632,7 +632,7 @@ EOF
   # Build the harness launch argv (per-harness flags), then start tmux.
   local launch_argv=()
   while IFS= read -r _tok; do launch_argv+=("$_tok"); done \
-    < <(harness_launch_argv launch "$session_id" "$plugin_dir")
+    < <(harness_launch_argv launch "$session_id" "$working_dir" "$plugin_dir" "")
   local WORKER_ENV_ARGS=()
   harness_env_args
   tmux new-session -d -s "$tmux_name" -c "$working_dir" \
@@ -741,7 +741,7 @@ EOF
   # Build the harness resume argv (per-harness flags), then start/respawn tmux.
   local launch_argv=()
   while IFS= read -r _tok; do launch_argv+=("$_tok"); done \
-    < <(harness_launch_argv resume "$session_id" "$plugin_dir")
+    < <(harness_launch_argv resume "$session_id" "$working_dir" "$plugin_dir" "")
   local WORKER_ENV_ARGS=()
   harness_env_args
   local mode

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -302,11 +302,7 @@ cmd_read_turn() {
     echo "Error: Could not determine working directory from meta file" >&2
     return 1
   fi
-  if [ -d "$cwd" ]; then
-    cwd=$(cd "$cwd" && pwd -P)
-  fi
-  encoded="${cwd//\//-}"
-  log_file="$HOME/.claude/projects/${encoded}/${sid}.jsonl"
+  log_file=$(harness_transcript_path "$sid" "$cwd")
 
   if [ ! -f "$log_file" ]; then
     echo "Error: Session log not found at $log_file" >&2
@@ -372,11 +368,7 @@ cmd_converse() {
     echo "Error: Could not determine working directory from meta file" >&2
     return 1
   fi
-  if [ -d "$cwd" ]; then
-    cwd=$(cd "$cwd" && pwd -P)
-  fi
-  encoded="${cwd//\//-}"
-  log_file="$HOME/.claude/projects/${encoded}/${sid}.jsonl"
+  log_file=$(harness_transcript_path "$sid" "$cwd")
   event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
 
   count_text_messages() {

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -323,13 +323,21 @@ cmd_converse() {
   local prompt="${1:?Usage: converse [--with-turn] <prompt> [timeout=120]}"
   local timeout="${2:-120}"
 
-  local strategy sid cwd log_file event_file before_count=0 after_line=0
+  local strategy sid="" cwd log_file event_file before_count=0 after_line=0
   strategy=$(harness_id_strategy)
 
+  # Resolve the worker up-front when possible so the turn baselines are captured
+  # BEFORE sending — always for assign; for derive on the 2nd+ turn the meta
+  # already exists. (A derive worker's FIRST prompt isn't registered yet, so the
+  # baselines correctly stay 0 — there is no prior turn to be relative to.)
   if [ "$strategy" = "assign" ]; then
     sid=$(resolve_session "$WORKER")
+  else
+    sid=$(resolve_session "$WORKER" 2>/dev/null) || sid=""
+  fi
+  if [ -n "$sid" ]; then
     cwd=$(jq -r '.cwd' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null)
-    if [ -z "$cwd" ] || [ "$cwd" = "null" ]; then
+    if [ "$strategy" = "assign" ] && { [ -z "$cwd" ] || [ "$cwd" = "null" ]; }; then
       echo "Error: Could not determine working directory from meta file" >&2
       return 1
     fi
@@ -341,8 +349,8 @@ cmd_converse() {
 
   cmd_send "$prompt"
 
-  if [ "$strategy" = "derive" ]; then
-    # The first prompt self-registered the worker; resolve it now.
+  # A derive worker registering on THIS prompt (its first turn) is resolvable now.
+  if [ -z "$sid" ]; then
     sid=$(resolve_session "$WORKER" 2>/dev/null) || sid=""
     if [ -z "$sid" ]; then
       echo "Error: worker did not register a session after the prompt" >&2
@@ -467,37 +475,44 @@ cmd_send() {
 }
 
 cmd_stop() {
+  # Resolve the tmux session independently of the sid so a derive worker that
+  # never registered (only sidecar + homes + shim, no meta) is still stoppable
+  # and fully cleaned up (it staged a copy of the operator's creds in homes/).
   local sid tmux_name
-  sid=$(resolve_session "$WORKER")
-  tmux_name=$(jq -r '.tmux_name' "$_CSD_WORKER_DIR/${sid}.meta")
+  tmux_name=$(_worker_tmux_name "$WORKER")
+  sid=$(resolve_session "$WORKER" 2>/dev/null) || sid=""
+  if [ -n "$sid" ] && [ -f "$_CSD_WORKER_DIR/${sid}.meta" ]; then
+    tmux_name=$(jq -r '.tmux_name' "$_CSD_WORKER_DIR/${sid}.meta")
+  fi
 
   if tmux has-session -t "$tmux_name" 2>/dev/null; then
     tmux send-keys -t "$tmux_name" -l "$(harness_quit_keys)"
     tmux send-keys -t "$tmux_name" Enter
 
-    # Wait up to 10s for session_end
-    local event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
-    local deadline=$((SECONDS + 10))
-    while [ "$SECONDS" -lt "$deadline" ]; do
-      if [ -f "$event_file" ] && grep -q '"event":"session_end"' "$event_file"; then
-        sleep 1
-        break
-      fi
-      sleep 0.5
-    done
+    if [ -n "$sid" ]; then
+      # Wait up to 10s for session_end
+      local event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
+      local deadline=$((SECONDS + 10))
+      while [ "$SECONDS" -lt "$deadline" ]; do
+        if [ -f "$event_file" ] && grep -q '"event":"session_end"' "$event_file"; then
+          sleep 1
+          break
+        fi
+        sleep 0.5
+      done
+    fi
 
     if tmux has-session -t "$tmux_name" 2>/dev/null; then
       tmux kill-session -t "$tmux_name"
     fi
   fi
 
-  rm -f "$_CSD_WORKER_DIR/${sid}.events.jsonl"
-  rm -f "$_CSD_WORKER_DIR/${sid}.meta"
+  [ -n "$sid" ] && rm -f "$_CSD_WORKER_DIR/${sid}.events.jsonl" "$_CSD_WORKER_DIR/${sid}.meta"
   rm -f "$_CSD_WORKER_DIR/bin/${tmux_name}"
   rm -f "$_CSD_WORKER_DIR/${tmux_name}.harness"
   rm -rf "$_CSD_WORKER_DIR/homes/${tmux_name}"
 
-  echo "Worker $tmux_name ($sid) stopped. Shim removed."
+  echo "Worker $tmux_name (${sid:-unregistered}) stopped. Shim removed."
 }
 
 cmd_handoff() {
@@ -598,8 +613,10 @@ cmd_launch() {
   if [ "${1:-}" = "--" ]; then shift; fi
   local extra_args=("$@")
 
-  # Capture the invocation for the reproduce line
-  local original_argv=("$tmux_name" "$working_dir")
+  # Capture the invocation for the reproduce line (include --harness when non-default).
+  local original_argv=()
+  [ "$harness" != "claude" ] && original_argv+=("--harness" "$harness")
+  original_argv+=("$tmux_name" "$working_dir")
   if [ "${#extra_args[@]}" -gt 0 ]; then
     original_argv+=("--" "${extra_args[@]}")
   fi
@@ -634,7 +651,7 @@ EOF
   local session_id=""
   [ "$(harness_id_strategy)" = "assign" ] && session_id=$(uuidgen | tr '[:upper:]' '[:lower:]')
 
-  mkdir -p $_CSD_WORKER_DIR $_CSD_WORKER_DIR/bin
+  mkdir -p "$_CSD_WORKER_DIR" "$_CSD_WORKER_DIR/bin"
   # Best-effort back-compat: only symlink the legacy path when it doesn't already
   # exist (a leftover real /tmp/claude-workers dir from older csd is left alone;
   # relaunch any live pre-upgrade workers after this upgrade).
@@ -736,8 +753,10 @@ cmd_adopt() {
   if [ "${1:-}" = "--" ]; then shift; fi
   local extra_args=("$@")
 
-  # Capture the invocation for the reproduce line
-  local original_argv=("$tmux_name" "$working_dir" "$session_id")
+  # Capture the invocation for the reproduce line (include --harness when non-default).
+  local original_argv=()
+  [ "$harness" != "claude" ] && original_argv+=("--harness" "$harness")
+  original_argv+=("$tmux_name" "$working_dir" "$session_id")
   if [ "${#extra_args[@]}" -gt 0 ]; then
     original_argv+=("--" "${extra_args[@]}")
   fi
@@ -770,7 +789,7 @@ EOF
     return 1
   fi
 
-  mkdir -p $_CSD_WORKER_DIR $_CSD_WORKER_DIR/bin
+  mkdir -p "$_CSD_WORKER_DIR" "$_CSD_WORKER_DIR/bin"
   # Best-effort back-compat: only symlink the legacy path when it doesn't already
   # exist (a leftover real /tmp/claude-workers dir from older csd is left alone;
   # relaunch any live pre-upgrade workers after this upgrade).

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -558,7 +558,12 @@ EOF
 
 
 cmd_launch() {
-  local tmux_name="${1:?Usage: launch <tmux-name> <cwd> [-- claude-args...]}"
+  local harness="claude"
+  while [ "${1:-}" = "--harness" ] || [[ "${1:-}" == --harness=* ]]; do
+    if [ "$1" = "--harness" ]; then harness="$2"; shift 2; else harness="${1#--harness=}"; shift; fi
+  done
+  _load_driver "$harness"
+  local tmux_name="${1:?Usage: launch [--harness <name>] <tmux-name> <cwd> [-- claude-args...]}"
   local working_dir="${2:?Usage: launch <tmux-name> <cwd> [-- claude-args...]}"
   shift 2
   # Skip a leading -- separator if present
@@ -606,8 +611,9 @@ EOF
     --arg session_id "$session_id" \
     --arg cwd "$working_dir" \
     --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    --arg harness "$harness" \
     --argjson invocation "$invocation_json" \
-    '{tmux_name: $tmux_name, session_id: $session_id, cwd: $cwd, started_at: $started_at, invocation: $invocation}' \
+    '{tmux_name: $tmux_name, session_id: $session_id, cwd: $cwd, started_at: $started_at, harness: $harness, invocation: $invocation}' \
     > "$_CSD_WORKER_DIR/${session_id}.meta"
 
   # Collision check
@@ -655,7 +661,12 @@ EOF
 }
 
 cmd_adopt() {
-  local tmux_name="${1:?Usage: adopt <tmux-name> <cwd> <session-id> [-- claude-args...]}"
+  local harness="claude"
+  while [ "${1:-}" = "--harness" ] || [[ "${1:-}" == --harness=* ]]; do
+    if [ "$1" = "--harness" ]; then harness="$2"; shift 2; else harness="${1#--harness=}"; shift; fi
+  done
+  _load_driver "$harness"
+  local tmux_name="${1:?Usage: adopt [--harness <name>] <tmux-name> <cwd> <session-id> [-- claude-args...]}"
   local working_dir="${2:?Usage: adopt <tmux-name> <cwd> <session-id> [-- claude-args...]}"
   local session_id="${3:?Usage: adopt <tmux-name> <cwd> <session-id> [-- claude-args...]}"
   shift 3
@@ -710,8 +721,9 @@ EOF
     --arg session_id "$session_id" \
     --arg cwd "$working_dir" \
     --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    --arg harness "$harness" \
     --argjson invocation "$invocation_json" \
-    '{tmux_name: $tmux_name, session_id: $session_id, cwd: $cwd, started_at: $started_at, invocation: $invocation}' \
+    '{tmux_name: $tmux_name, session_id: $session_id, cwd: $cwd, started_at: $started_at, harness: $harness, invocation: $invocation}' \
     > "$_CSD_WORKER_DIR/${session_id}.meta"
 
   # Build the harness resume argv (per-harness flags), then start/respawn tmux.

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -309,47 +309,9 @@ cmd_read_turn() {
     return 1
   fi
 
-  last_prompt_line=$(grep -n '"type":"user"' "$log_file" \
-    | grep -v '"tool_result"' \
-    | grep -v '<local-command' \
-    | grep -v '<command-name>' \
-    | tail -1 \
-    | cut -d: -f1)
-
-  if [ -z "$last_prompt_line" ]; then
-    echo "No user prompt found in session log" >&2
-    return 1
-  fi
-
-  tail -n +"$last_prompt_line" "$log_file" \
-    | jq -r --argjson full "$full" '
-      select(.type == "assistant" or .type == "user") |
-      if .type == "user" then
-        if (.message.content | type) == "string" then
-          if (.message.content | test("^<(local-command|command-name)")) then empty
-          else "---\n\n**Prompt:** " + .message.content + "\n" end
-        else
-          .message.content[] | select(.type == "tool_result") |
-          if .is_error then
-            "**Tool Error:**\n```\n" + (.content // "(no output)") + "\n```\n"
-          else
-            if $full then
-              "**Result:**\n```\n" + (.content // "(no output)") + "\n```\n"
-            else
-              "**Result:**\n```\n" + ((.content // "(no output)") | split("\n") | if length > 5 then (.[0:5] | join("\n")) + "\n... (" + (length | tostring) + " lines total)" else join("\n") end) + "\n```\n"
-            end
-          end
-        end
-      elif .type == "assistant" then
-        .message.content[] |
-        if .type == "thinking" then "> **Thinking:** " + (.thinking | split("\n") | join("\n> ")) + "\n"
-        elif .type == "text" then .text + "\n"
-        elif .type == "tool_use" then "**Tool: " + .name + "**\n```json\n" + (.input | tostring) + "\n```\n"
-        else empty
-        end
-      else empty
-      end
-    ' 2>/dev/null
+  local parse_full=()
+  [ "$full" = true ] && parse_full=(--full)
+  harness_parse_turn "$log_file" "${parse_full[@]+"${parse_full[@]}"}"
 }
 
 cmd_converse() {
@@ -371,20 +333,8 @@ cmd_converse() {
   log_file=$(harness_transcript_path "$sid" "$cwd")
   event_file="$_CSD_WORKER_DIR/${sid}.events.jsonl"
 
-  count_text_messages() {
-    if [ ! -f "$log_file" ]; then echo 0; return; fi
-    local r
-    r=$(grep '"type":"assistant"' "$log_file" \
-        | jq -s '[.[] | select(.message.content | (type == "array") and any(.type == "text"))] | length' 2>/dev/null) || r=0
-    echo "$r"
-  }
-  last_text_response() {
-    grep '"type":"assistant"' "$log_file" \
-      | jq -rs 'map(select(.message.content | (type == "array") and any(.type == "text"))) | last | [.message.content[] | select(.type == "text") | .text] | join("\n")' 2>/dev/null
-  }
-
   local before_count after_line
-  before_count=$(count_text_messages)
+  before_count=$(harness_count_text "$log_file")
   after_line=0
   [ -f "$event_file" ] && after_line=$(wc -l < "$event_file" | tr -d ' ')
 
@@ -403,14 +353,14 @@ cmd_converse() {
   local after_count
   for _ in $(seq 1 20); do
     [ -f "$log_file" ] || { sleep 0.1; continue; }
-    after_count=$(count_text_messages)
+    after_count=$(harness_count_text "$log_file")
     if [ "$after_count" -gt "$before_count" ]; then
       if [ "$with_turn" -eq 1 ]; then
         cmd_read_turn
         return 0
       fi
       local response
-      response=$(last_text_response)
+      response=$(harness_last_text "$log_file")
       if [ -n "$response" ]; then
         echo "$response"
         return 0

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -614,81 +614,6 @@ EOF
   echo "$shim_path"
 }
 
-# Provider/auth environment variables that Claude Code resolves directly from
-# the process environment. We pin these for the worker (issue #18).
-#
-# Why pinning is necessary — the tmux inheritance trap:
-#   `tmux new-session` does NOT inherit *this* process's environment. A new
-#   session inherits the tmux SERVER's global environment, captured when the
-#   server first started (often an older, unrelated shell). So a stale
-#   `CLAUDE_CODE_USE_BEDROCK=1` left in the server's global env by some earlier
-#   session silently leaks into every worker — even after the operator removed
-#   it from their shell and settings. `tmux show-environment -g` reveals it.
-#
-# Why it breaks auth — how Claude Code reads these (verified against the
-# v2.1.x binary's provider-selection and auth code):
-#   * Provider selection is, in effect,
-#       USE_BEDROCK ? "bedrock" : USE_FOUNDRY ? "foundry" : USE_ANTHROPIC_AWS ?
-#       "anthropicAws" : USE_MANTLE ? "mantle" : USE_VERTEX ? "vertex"
-#                                                            : "firstParty"
-#     read straight from the environment and NOT gated by
-#     PROVIDER_MANAGED_BY_HOST. A stale USE_BEDROCK therefore forces the worker
-#     onto Bedrock (and a likely-expired token) → 403 on the first turn. This
-#     is the root cause of #18.
-#   * CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST tells Claude Code an embedding host
-#     (cmux, an IDE extension) manages provider routing and auth. The worker
-#     reaches that host through environment it already inherits (the host auth
-#     token lives in the env var named by CLAUDE_CODE_HOST_AUTH_ENV_VAR,
-#     default ANTHROPIC_AUTH_TOKEN). Blanket-clearing this flag severs
-#     host-brokered auth, which is the other half of #18.
-#   * CLAUDE_CODE_SSE_PORT is the controller's IDE (VSCode/JetBrains)
-#     integration socket — purely IDE discovery, never the auth channel. A
-#     headless worker has no IDE and must not auto-connect to the controller's,
-#     so it is always pinned empty.
-#
-# Fix — clear stale values, never force new ones. For each cluster var:
-#   * If it is NOT set in the controller's (this process's) environment, pin it
-#     empty in the worker. This is what kills a stale tmux-global value.
-#   * If it IS set here, leave it alone so it inherits through tmux's normal
-#     environment — together with the credentials that travel with it (the host
-#     auth token, AWS/Vertex creds, base URLs). We deliberately do NOT force the
-#     value via `-e`: forcing a provider selector or PROVIDER_MANAGED_BY_HOST on
-#     while its credentials fail to reach the worker would just trade one auth
-#     failure for another, and forwarding the secrets explicitly would put them
-#     on the tmux command line (ps-visible). Selector and credentials must move
-#     together or not at all. CLAUDE_CODE_SSE_PORT is the exception: it is
-#     always pinned empty (IDE-only, never an auth channel).
-#
-# Net effect matches the field-proven workaround for #18: stop force-clearing
-# PROVIDER_MANAGED_BY_HOST (let host-brokered auth inherit) while killing the
-# stale CLAUDE_CODE_USE_BEDROCK that was hijacking the provider.
-_PROVIDER_ENV_VARS=(
-  CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
-  CLAUDE_CODE_USE_BEDROCK
-  CLAUDE_CODE_USE_VERTEX
-  CLAUDE_CODE_USE_FOUNDRY
-  CLAUDE_CODE_USE_ANTHROPIC_AWS
-  CLAUDE_CODE_USE_MANTLE
-)
-
-# Populate WORKER_ENV_ARGS (a caller-declared array) with the `-e VAR=...` pairs
-# to hand to `tmux new-session` / `tmux respawn-pane`. CLAUDE_CODE_SSE_PORT is
-# always pinned empty; each provider/auth var is pinned empty only when absent
-# from this process's environment, otherwise left to inherit.
-_build_worker_env_args() {
-  WORKER_ENV_ARGS=(-e "CLAUDE_CODE_SSE_PORT=")
-  local var val
-  for var in "${_PROVIDER_ENV_VARS[@]}"; do
-    # Leave a var to inherit only when this process has a NON-EMPTY value for it
-    # (matching Claude Code's own truthiness check, where empty == false). Empty
-    # or unset here means "the controller is not using this provider", so pin it
-    # empty to override any stale, non-empty tmux-global value.
-    val=$(printenv "$var" 2>/dev/null) || val=""
-    if [ -z "$val" ]; then
-      WORKER_ENV_ARGS+=(-e "${var}=")
-    fi
-  done
-}
 
 cmd_launch() {
   local tmux_name="${1:?Usage: launch <tmux-name> <cwd> [-- claude-args...]}"
@@ -753,7 +678,7 @@ EOF
   # Start tmux. Allow override of the claude binary via CSD_CLAUDE_BIN for tests.
   local claude_bin="${CSD_CLAUDE_BIN:-claude}"
   local WORKER_ENV_ARGS=()
-  _build_worker_env_args
+  harness_env_args
   tmux new-session -d -s "$tmux_name" -c "$working_dir" \
     "${WORKER_ENV_ARGS[@]}" \
     "$claude_bin" --session-id "$session_id" --plugin-dir "$plugin_dir" \
@@ -851,7 +776,7 @@ EOF
   # Start (or respawn) the worker with --resume instead of --session-id.
   local claude_bin="${CSD_CLAUDE_BIN:-claude}"
   local WORKER_ENV_ARGS=()
-  _build_worker_env_args
+  harness_env_args
   local mode
   if tmux has-session -t "$tmux_name" 2>/dev/null; then
     # A pane with this name already exists — e.g. restored by tmux-resurrect /

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -913,6 +913,9 @@ if [ "${1:-}" = "poll" ]; then
   shift
   _phar="${1:?Usage: csd poll <harness> <session_dir> <worker_dir> <tmux_name>}"; shift
   _load_driver "$_phar"
+  if ! declare -F harness_poll >/dev/null 2>&1; then
+    echo "Error: harness '$_phar' has no poll control plane" >&2; exit 2
+  fi
   harness_poll "$@"
   exit $?
 fi

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -446,7 +446,7 @@ cmd_stop() {
   tmux_name=$(jq -r '.tmux_name' "$_CSD_WORKER_DIR/${sid}.meta")
 
   if tmux has-session -t "$tmux_name" 2>/dev/null; then
-    tmux send-keys -t "$tmux_name" -l '/exit'
+    tmux send-keys -t "$tmux_name" -l "$(harness_quit_keys)"
     tmux send-keys -t "$tmux_name" Enter
 
     # Wait up to 10s for session_end

--- a/skills/driving-claude-code-sessions/scripts/csd
+++ b/skills/driving-claude-code-sessions/scripts/csd
@@ -675,17 +675,16 @@ EOF
     return 1
   fi
 
-  # Start tmux. Allow override of the claude binary via CSD_CLAUDE_BIN for tests.
-  local claude_bin="${CSD_CLAUDE_BIN:-claude}"
+  # Build the harness launch argv (per-harness flags), then start tmux.
+  local launch_argv=()
+  while IFS= read -r _tok; do launch_argv+=("$_tok"); done \
+    < <(harness_launch_argv launch "$session_id" "$plugin_dir")
   local WORKER_ENV_ARGS=()
   harness_env_args
   tmux new-session -d -s "$tmux_name" -c "$working_dir" \
     "${WORKER_ENV_ARGS[@]}" \
-    "$claude_bin" --session-id "$session_id" --plugin-dir "$plugin_dir" \
-      --settings '{"skipDangerousModePermissionPrompt":true}' \
-      --dangerously-skip-permissions \
-      --disallowed-tools AskUserQuestion \
-      "${extra_args[@]+"${extra_args[@]}"}"
+    "${launch_argv[@]}" \
+    "${extra_args[@]+"${extra_args[@]}"}"
 
   # Accept any trust dialog and block until the worker emits session_start.
   _await_session_start "$tmux_name" "$session_id" || return 1
@@ -773,8 +772,10 @@ EOF
     '{tmux_name: $tmux_name, session_id: $session_id, cwd: $cwd, started_at: $started_at, invocation: $invocation}' \
     > "$_CSD_WORKER_DIR/${session_id}.meta"
 
-  # Start (or respawn) the worker with --resume instead of --session-id.
-  local claude_bin="${CSD_CLAUDE_BIN:-claude}"
+  # Build the harness resume argv (per-harness flags), then start/respawn tmux.
+  local launch_argv=()
+  while IFS= read -r _tok; do launch_argv+=("$_tok"); done \
+    < <(harness_launch_argv resume "$session_id" "$plugin_dir")
   local WORKER_ENV_ARGS=()
   harness_env_args
   local mode
@@ -784,21 +785,13 @@ EOF
     # window layout is preserved; -k kills whatever dead command the restore left.
     mode="respawned existing pane"
     tmux respawn-pane -k -t "$tmux_name" -c "$working_dir" \
-      "${WORKER_ENV_ARGS[@]}" \
-      "$claude_bin" --resume "$session_id" --plugin-dir "$plugin_dir" \
-        --settings '{"skipDangerousModePermissionPrompt":true}' \
-        --dangerously-skip-permissions \
-        --disallowed-tools AskUserQuestion \
-        "${extra_args[@]+"${extra_args[@]}"}"
+      "${WORKER_ENV_ARGS[@]}" "${launch_argv[@]}" \
+      "${extra_args[@]+"${extra_args[@]}"}"
   else
     mode="opened new pane"
     tmux new-session -d -s "$tmux_name" -c "$working_dir" \
-      "${WORKER_ENV_ARGS[@]}" \
-      "$claude_bin" --resume "$session_id" --plugin-dir "$plugin_dir" \
-        --settings '{"skipDangerousModePermissionPrompt":true}' \
-        --dangerously-skip-permissions \
-        --disallowed-tools AskUserQuestion \
-        "${extra_args[@]+"${extra_args[@]}"}"
+      "${WORKER_ENV_ARGS[@]}" "${launch_argv[@]}" \
+      "${extra_args[@]+"${extra_args[@]}"}"
   fi
 
   # Accept any trust dialog and block until the worker emits session_start.

--- a/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
+++ b/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
@@ -49,3 +49,11 @@ harness_launch_argv() {
     --dangerously-skip-permissions \
     --disallowed-tools AskUserQuestion
 }
+
+# Echo the transcript path for <sid> in <cwd> (cwd resolved to absolute first).
+harness_transcript_path() {
+  local sid="$1" cwd="$2"
+  if [ -d "$cwd" ]; then cwd=$(cd "$cwd" && pwd -P); fi
+  local encoded="${cwd//\//-}"
+  echo "$HOME/.claude/projects/${encoded}/${sid}.jsonl"
+}

--- a/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
+++ b/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
@@ -33,3 +33,19 @@ harness_env_args() {
     fi
   done
 }
+
+# Print the harness command + flags (one token per line) for `mode`:
+#   launch -> --session-id <sid>;  resume -> --resume <sid>
+# The spine wraps this with tmux + env args + any user extra-args.
+harness_launch_argv() {
+  local mode="$1" sid="$2" plugin_dir="$3"
+  local bin idflag
+  bin=$(harness_bin)
+  idflag="--session-id"
+  [ "$mode" = "resume" ] && idflag="--resume"
+  printf '%s\n' \
+    "$bin" "$idflag" "$sid" --plugin-dir "$plugin_dir" \
+    --settings '{"skipDangerousModePermissionPrompt":true}' \
+    --dangerously-skip-permissions \
+    --disallowed-tools AskUserQuestion
+}

--- a/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
+++ b/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
@@ -57,3 +57,64 @@ harness_transcript_path() {
   local encoded="${cwd//\//-}"
   echo "$HOME/.claude/projects/${encoded}/${sid}.jsonl"
 }
+
+# Render the last turn of <transcript> as markdown. With --full, tool results
+# are shown complete; otherwise truncated to 5 lines.
+harness_parse_turn() {
+  local log_file="$1" full=false
+  [ "${2:-}" = "--full" ] && full=true
+  local last_prompt_line
+  last_prompt_line=$(grep -n '"type":"user"' "$log_file" \
+    | grep -v '"tool_result"' | grep -v '<local-command' | grep -v '<command-name>' \
+    | tail -1 | cut -d: -f1)
+  if [ -z "$last_prompt_line" ]; then
+    echo "No user prompt found in session log" >&2
+    return 1
+  fi
+  tail -n +"$last_prompt_line" "$log_file" \
+    | jq -r --argjson full "$full" '
+      select(.type == "assistant" or .type == "user") |
+      if .type == "user" then
+        if (.message.content | type) == "string" then
+          if (.message.content | test("^<(local-command|command-name)")) then empty
+          else "---\n\n**Prompt:** " + .message.content + "\n" end
+        else
+          .message.content[] | select(.type == "tool_result") |
+          if .is_error then
+            "**Tool Error:**\n```\n" + (.content // "(no output)") + "\n```\n"
+          else
+            if $full then
+              "**Result:**\n```\n" + (.content // "(no output)") + "\n```\n"
+            else
+              "**Result:**\n```\n" + ((.content // "(no output)") | split("\n") | if length > 5 then (.[0:5] | join("\n")) + "\n... (" + (length | tostring) + " lines total)" else join("\n") end) + "\n```\n"
+            end
+          end
+        end
+      elif .type == "assistant" then
+        .message.content[] |
+        if .type == "thinking" then "> **Thinking:** " + (.thinking | split("\n") | join("\n> ")) + "\n"
+        elif .type == "text" then .text + "\n"
+        elif .type == "tool_use" then "**Tool: " + .name + "**\n```json\n" + (.input | tostring) + "\n```\n"
+        else empty
+        end
+      else empty
+      end
+    ' 2>/dev/null
+}
+
+# Echo the count of assistant messages that contain a text block.
+harness_count_text() {
+  local log_file="$1"
+  [ -f "$log_file" ] || { echo 0; return; }
+  local r
+  r=$(grep '"type":"assistant"' "$log_file" \
+      | jq -s '[.[] | select(.message.content | (type == "array") and any(.type == "text"))] | length' 2>/dev/null) || r=0
+  echo "$r"
+}
+
+# Echo the text of the last assistant message that has a text block.
+harness_last_text() {
+  local log_file="$1"
+  grep '"type":"assistant"' "$log_file" \
+    | jq -rs 'map(select(.message.content | (type == "array") and any(.type == "text"))) | last | [.message.content[] | select(.type == "text") | .text] | join("\n")' 2>/dev/null
+}

--- a/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
+++ b/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
@@ -7,3 +7,29 @@ harness_bin()           { echo "${CSD_CLAUDE_BIN:-claude}"; }
 harness_control_plane() { echo "hooks"; }
 harness_id_strategy()   { echo "assign"; }
 harness_quit_keys()     { echo "/exit"; }
+
+# Provider/auth vars Claude resolves from the process env (issue #18). Pinned
+# empty when unset here (kills stale tmux-global values that leak in because a
+# new tmux session inherits the SERVER's global env, not this process's); left
+# to inherit when set here (so credentials travel with the selector).
+# CLAUDE_CODE_SSE_PORT is always pinned empty (IDE-only, never an auth channel).
+_CLAUDE_PROVIDER_ENV_VARS=(
+  CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
+  CLAUDE_CODE_USE_BEDROCK
+  CLAUDE_CODE_USE_VERTEX
+  CLAUDE_CODE_USE_FOUNDRY
+  CLAUDE_CODE_USE_ANTHROPIC_AWS
+  CLAUDE_CODE_USE_MANTLE
+)
+
+# Populate the caller-declared WORKER_ENV_ARGS array with -e VAR=… pairs.
+harness_env_args() {
+  WORKER_ENV_ARGS=(-e "CLAUDE_CODE_SSE_PORT=")
+  local var val
+  for var in "${_CLAUDE_PROVIDER_ENV_VARS[@]}"; do
+    val=$(printenv "$var" 2>/dev/null) || val=""
+    if [ -z "$val" ]; then
+      WORKER_ENV_ARGS+=(-e "${var}=")
+    fi
+  done
+}

--- a/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
+++ b/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Claude Code harness driver for csd. Sourced, not executed. Implements the
+# harness slot contract (docs/superpowers/specs/2026-06-05-csd-multiharness-design.md).
+
+harness_id()            { echo "claude"; }
+harness_bin()           { echo "${CSD_CLAUDE_BIN:-claude}"; }
+harness_control_plane() { echo "hooks"; }
+harness_id_strategy()   { echo "assign"; }
+harness_quit_keys()     { echo "/exit"; }

--- a/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
+++ b/skills/driving-claude-code-sessions/scripts/drivers/claude.sh
@@ -38,7 +38,7 @@ harness_env_args() {
 #   launch -> --session-id <sid>;  resume -> --resume <sid>
 # The spine wraps this with tmux + env args + any user extra-args.
 harness_launch_argv() {
-  local mode="$1" sid="$2" plugin_dir="$3"
+  local mode="$1" sid="$2" plugin_dir="$4"
   local bin idflag
   bin=$(harness_bin)
   idflag="--session-id"
@@ -49,6 +49,13 @@ harness_launch_argv() {
     --dangerously-skip-permissions \
     --disallowed-tools AskUserQuestion
 }
+
+# Claude needs no per-worker prep, no post-launch gate dismissal. Claude
+# readiness is session_start (the spine calls _await_session_start directly on
+# the assign path); these slots exist for the derive path's launch sequence.
+harness_prepare()     { :; }
+harness_post_launch() { :; }
+harness_await_ready() { :; }
 
 # Echo the transcript path for <sid> in <cwd> (cwd resolved to absolute first).
 harness_transcript_path() {

--- a/skills/driving-claude-code-sessions/scripts/drivers/codex.sh
+++ b/skills/driving-claude-code-sessions/scripts/drivers/codex.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Codex (OpenAI) harness driver for csd. Sourced, not executed. derive-id +
+# hook control plane. Validated end-to-end against codex 0.134 (spec Appendix B).
+
+harness_id()            { echo "codex"; }
+harness_bin()           { echo "${CSD_CODEX_BIN:-codex}"; }
+harness_control_plane() { echo "hooks"; }
+harness_id_strategy()   { echo "derive"; }
+harness_quit_keys()     { echo "/quit"; }
+
+# Per-worker config: a CODEX_HOME holding a config.toml that registers the
+# self-registering hook on each lifecycle event, plus project trust. Auth is
+# staged (the operator's ~/.codex/auth.json) so the worker authenticates as the
+# operator. Reads CSD_PLUGIN_DIR (set by the spine) to locate emit-event-codex.
+harness_prepare() {
+  local tmux_name="$1" cwd="$2" home="$3"
+  local hook="${CSD_PLUGIN_DIR}/hooks/emit-event-codex"
+  local model="${CSD_CODEX_MODEL:-gpt-5.5}"
+  mkdir -p "$home"
+  [ -f "$HOME/.codex/auth.json" ] && cp "$HOME/.codex/auth.json" "$home/" 2>/dev/null || true
+  {
+    echo "model = \"$model\""
+    echo "model_reasoning_effort = \"low\""
+    echo "[projects.\"$cwd\"]"
+    echo "trust_level = \"trusted\""
+    local ev
+    for ev in SessionStart UserPromptSubmit PreToolUse PostToolUse Stop SessionEnd; do
+      echo "[[hooks.$ev]]"
+      case "$ev" in PreToolUse|PostToolUse) echo "matcher = \".*\"" ;; esac
+      echo "[[hooks.$ev.hooks]]"
+      echo "type = \"command\""
+      echo "command = \"$hook $tmux_name $cwd $_CSD_WORKER_DIR\""
+    done
+  } > "$home/config.toml"
+}
+
+# harness_launch_argv <mode> <sid> <cwd> <plugin_dir> <worker_home>
+# Codex ignores sid (derive), plugin_dir (hooks via CODEX_HOME), worker_home
+# (passed as env). Interactive; -C sets the workdir.
+harness_launch_argv() {
+  local cwd="$3"
+  printf '%s\n' \
+    "$(harness_bin)" \
+    --dangerously-bypass-approvals-and-sandbox \
+    --dangerously-bypass-hook-trust \
+    -C "$cwd"
+}
+
+# CODEX_HOME points codex at the per-worker config/auth/sessions dir. The spine
+# sets _CSD_CURRENT_WORKER_HOME before launch; default-guarded for set -u.
+harness_env_args() {
+  WORKER_ENV_ARGS=(-e "CODEX_HOME=${_CSD_CURRENT_WORKER_HOME:-}")
+}
+
+# Dismiss the "Hooks need review" trust gate (the bypass flag does NOT skip it).
+harness_post_launch() {
+  local tmux_name="$1" deadline=$((SECONDS + 8)) pane
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    pane=$(tmux capture-pane -t "$tmux_name" -p 2>/dev/null || true)
+    if echo "$pane" | grep -qiE 'hooks need review|trust all|review'; then
+      tmux send-keys -t "$tmux_name" -l '2'; sleep 0.3
+      tmux send-keys -t "$tmux_name" Enter
+      return 0
+    fi
+    sleep 0.25
+  done
+}
+
+# derive readiness: session_start fires at the first prompt, not boot. Wait for
+# the composer glyph, else settle. The first send re-confirms via self-registration.
+harness_await_ready() {
+  local tmux_name="$1" deadline=$((SECONDS + 20)) pane
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    pane=$(tmux capture-pane -t "$tmux_name" -p 2>/dev/null || true)
+    echo "$pane" | grep -q '›' && return 0
+    sleep 0.5
+  done
+  return 0
+}
+
+# The transcript path is recorded by the self-registering hook; read from meta.
+harness_transcript_path() {
+  local sid="$1"
+  jq -r '.transcript_path // empty' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null
+}
+
+# Render the last turn of a codex rollout as markdown.
+harness_parse_turn() {
+  local rollout="$1"
+  [ -f "$rollout" ] || { echo "No rollout at $rollout" >&2; return 1; }
+  local start
+  start=$(grep -n '"type":"response_item"' "$rollout" | grep '"role":"user"' | tail -1 | cut -d: -f1)
+  [ -z "$start" ] && start=1
+  tail -n +"$start" "$rollout" | jq -r '
+    select(.type=="response_item") | .payload as $p |
+    if   $p.type=="message" then "**[" + $p.role + "]** " + ([$p.content[]?.text // $p.content[]?.output_text // ""] | join("")) + "\n"
+    elif $p.type=="reasoning" then "> **Thinking:** " + (($p.summary // []) | map(.text // .) | join(" ")) + "\n"
+    elif $p.type=="function_call" then "**Tool: " + $p.name + "**\n```\n" + ($p.arguments | tostring) + "\n```\n"
+    elif $p.type=="function_call_output" then "**Result:**\n```\n" + ($p.output | tostring) + "\n```\n"
+    else empty end' 2>/dev/null
+}
+
+# Count assistant agent_message records (one value, set -e safe).
+harness_count_text() {
+  local rollout="$1" c
+  [ -f "$rollout" ] || { echo 0; return; }
+  c=$(grep -c '"agent_message"' "$rollout" 2>/dev/null) || c=0
+  echo "$c"
+}
+
+# Last assistant message text.
+harness_last_text() {
+  local rollout="$1"
+  [ -f "$rollout" ] || return 0
+  grep '"type":"event_msg"' "$rollout" \
+    | jq -rs 'map(select(.payload.type=="agent_message")) | last | .payload.message // ""' 2>/dev/null
+}

--- a/skills/driving-claude-code-sessions/scripts/drivers/codex.sh
+++ b/skills/driving-claude-code-sessions/scripts/drivers/codex.sh
@@ -57,7 +57,7 @@ harness_post_launch() {
   local tmux_name="$1" deadline=$((SECONDS + 8)) pane
   while [ "$SECONDS" -lt "$deadline" ]; do
     pane=$(tmux capture-pane -t "$tmux_name" -p 2>/dev/null || true)
-    if echo "$pane" | grep -qiE 'hooks need review|trust all|review'; then
+    if echo "$pane" | grep -qiE 'hooks need review|trust all and continue|trust all'; then
       tmux send-keys -t "$tmux_name" -l '2'; sleep 0.3
       tmux send-keys -t "$tmux_name" Enter
       return 0
@@ -115,5 +115,5 @@ harness_last_text() {
   local rollout="$1"
   [ -f "$rollout" ] || return 0
   grep '"type":"event_msg"' "$rollout" \
-    | jq -rs 'map(select(.payload.type=="agent_message")) | last | .payload.message // ""' 2>/dev/null
+    | jq -rs 'map(select(.payload.type=="agent_message")) | last | .payload.message // ""' 2>/dev/null || true
 }

--- a/skills/driving-claude-code-sessions/scripts/drivers/codex.sh
+++ b/skills/driving-claude-code-sessions/scripts/drivers/codex.sh
@@ -88,8 +88,10 @@ harness_transcript_path() {
 harness_parse_turn() {
   local rollout="$1"
   [ -f "$rollout" ] || { echo "No rollout at $rollout" >&2; return 1; }
-  local start
-  start=$(grep -n '"type":"response_item"' "$rollout" | grep '"role":"user"' | tail -1 | cut -d: -f1)
+  # Find the last user message line. The grep pipeline can legitimately match
+  # nothing (e.g. a tool-only turn); guard against set -e/pipefail aborting here.
+  local start=""
+  start=$(grep -n '"type":"response_item"' "$rollout" | grep '"role":"user"' | tail -1 | cut -d: -f1) || start=""
   [ -z "$start" ] && start=1
   tail -n +"$start" "$rollout" | jq -r '
     select(.type=="response_item") | .payload as $p |

--- a/skills/driving-claude-code-sessions/scripts/drivers/pi.sh
+++ b/skills/driving-claude-code-sessions/scripts/drivers/pi.sh
@@ -16,17 +16,26 @@ harness_quit_keys()     { echo "/quit"; }
 # worker's tmux session is gone. Runs in a second tmux window of the worker.
 harness_poll() {
   local sd="$1" wd="$2" tn="$3" f="" i
-  for i in $(seq 1 120); do
-    f=$(find "$sd" -name '*.jsonl' -type f 2>/dev/null | head -1)
-    [ -n "$f" ] && break
+  # Discover the NEWEST session file (ls -t, not unsorted find), retrying.
+  for i in $(seq 1 240); do
+    f=$(ls -t "$sd"/*.jsonl 2>/dev/null | head -1) || f=""
+    [ -n "$f" ] && [ -f "$f" ] && break
+    f=""
     tmux has-session -t "$tn" 2>/dev/null || return 0
     sleep 0.5
   done
   [ -z "$f" ] && return 0
-  local sid cwd
-  sid=$(head -1 "$f" | jq -r '.id // empty' 2>/dev/null) || sid=""
-  cwd=$(head -1 "$f" | jq -r '.cwd // empty' 2>/dev/null) || cwd=""
+  # Read the session id from line 1, retrying: find can see the file before pi
+  # flushes line 1 (TOCTOU). A one-shot read would kill the sole event producer.
+  local sid="" cwd=""
+  for i in $(seq 1 240); do
+    sid=$(head -1 "$f" 2>/dev/null | jq -r '.id // empty' 2>/dev/null) || sid=""
+    [ -n "$sid" ] && break
+    tmux has-session -t "$tn" 2>/dev/null || return 0
+    sleep 0.5
+  done
   [ -z "$sid" ] && return 0
+  cwd=$(head -1 "$f" 2>/dev/null | jq -r '.cwd // empty' 2>/dev/null) || cwd=""
   if [ ! -f "$wd/$sid.meta" ]; then
     jq -n --arg tn "$tn" --arg sid "$sid" --arg cwd "$cwd" --arg tp "$f" \
       '{tmux_name:$tn, session_id:$sid, cwd:$cwd, transcript_path:$tp, harness:"pi"}' \
@@ -35,11 +44,15 @@ harness_poll() {
   local ev="$wd/$sid.events.jsonl"
   _pi_emit(){ jq -cn --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --arg e "$1" '{ts:$ts, event:$e}' >> "$ev"; }
   _pi_emit session_start
-  local prev=1 n line typ role stop
+  local prev=1 n line typ role stop read_cnt
   while true; do
-    n=$(wc -l < "$f" | tr -d ' ')
-    if [ "$n" -gt "$prev" ]; then
+    # File vanished (rotation/cleanup) -> end the session cleanly, don't crash.
+    if [ ! -f "$f" ]; then _pi_emit session_end; break; fi
+    n=$(wc -l < "$f" 2>/dev/null | tr -d ' ') || n=""
+    if [ -n "$n" ] && [ "$n" -gt "$prev" ]; then
+      read_cnt=0
       while IFS= read -r line; do
+        read_cnt=$((read_cnt + 1))   # count every line read (advance offset by what we consumed)
         [ -z "$line" ] && continue
         typ=$(printf '%s' "$line" | jq -r '.type // empty' 2>/dev/null) || typ=""
         role=$(printf '%s' "$line" | jq -r '.message.role // empty' 2>/dev/null) || role=""
@@ -47,12 +60,11 @@ harness_poll() {
         case "$typ:$role:$stop" in
           message:user:*)            _pi_emit user_prompt_submit ;;
           message:assistant:toolUse) _pi_emit pre_tool_use ;;
+          message:assistant:?*)      _pi_emit stop ;;   # any non-toolUse terminal stopReason
           message:toolResult:*)      _pi_emit post_tool_use ;;
-          message:assistant:stop)    _pi_emit stop ;;
-          message:assistant:error)   _pi_emit stop ;;
         esac
-      done < <(tail -n +"$((prev+1))" "$f")
-      prev=$n
+      done < <(tail -n +"$((prev + 1))" "$f" 2>/dev/null)
+      prev=$((prev + read_cnt))      # advance by lines actually consumed, NOT the stale wc -l
     fi
     tmux has-session -t "$tn" 2>/dev/null || { _pi_emit session_end; break; }
     sleep 0.3

--- a/skills/driving-claude-code-sessions/scripts/drivers/pi.sh
+++ b/skills/driving-claude-code-sessions/scripts/drivers/pi.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Pi (Earendil) harness driver for csd. Sourced, not executed. derive-id, but the
+# control plane is a POLLER (Pi has no hooks): `csd poll` tails the session JSONL,
+# self-registers the meta, and synthesizes the same events.jsonl the spine
+# consumes. Validated end-to-end against pi 0.75.3.
+
+harness_id()            { echo "pi"; }
+harness_bin()           { echo "${CSD_PI_BIN:-pi}"; }
+harness_control_plane() { echo "poll"; }
+harness_id_strategy()   { echo "derive"; }
+harness_quit_keys()     { echo "/quit"; }
+
+# harness_poll <session_dir> <worker_dir> <tmux_name>
+# Tail the newest session JSONL in <session_dir>; self-register <sid>.meta from
+# line 1; map records -> normalized events; exit (emitting session_end) when the
+# worker's tmux session is gone. Runs in a second tmux window of the worker.
+harness_poll() {
+  local sd="$1" wd="$2" tn="$3" f="" i
+  for i in $(seq 1 120); do
+    f=$(find "$sd" -name '*.jsonl' -type f 2>/dev/null | head -1)
+    [ -n "$f" ] && break
+    tmux has-session -t "$tn" 2>/dev/null || return 0
+    sleep 0.5
+  done
+  [ -z "$f" ] && return 0
+  local sid cwd
+  sid=$(head -1 "$f" | jq -r '.id // empty' 2>/dev/null) || sid=""
+  cwd=$(head -1 "$f" | jq -r '.cwd // empty' 2>/dev/null) || cwd=""
+  [ -z "$sid" ] && return 0
+  if [ ! -f "$wd/$sid.meta" ]; then
+    jq -n --arg tn "$tn" --arg sid "$sid" --arg cwd "$cwd" --arg tp "$f" \
+      '{tmux_name:$tn, session_id:$sid, cwd:$cwd, transcript_path:$tp, harness:"pi"}' \
+      > "$wd/$sid.meta"
+  fi
+  local ev="$wd/$sid.events.jsonl"
+  _pi_emit(){ jq -cn --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --arg e "$1" '{ts:$ts, event:$e}' >> "$ev"; }
+  _pi_emit session_start
+  local prev=1 n line typ role stop
+  while true; do
+    n=$(wc -l < "$f" | tr -d ' ')
+    if [ "$n" -gt "$prev" ]; then
+      while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        typ=$(printf '%s' "$line" | jq -r '.type // empty' 2>/dev/null) || typ=""
+        role=$(printf '%s' "$line" | jq -r '.message.role // empty' 2>/dev/null) || role=""
+        stop=$(printf '%s' "$line" | jq -r '.message.stopReason // empty' 2>/dev/null) || stop=""
+        case "$typ:$role:$stop" in
+          message:user:*)            _pi_emit user_prompt_submit ;;
+          message:assistant:toolUse) _pi_emit pre_tool_use ;;
+          message:toolResult:*)      _pi_emit post_tool_use ;;
+          message:assistant:stop)    _pi_emit stop ;;
+          message:assistant:error)   _pi_emit stop ;;
+        esac
+      done < <(tail -n +"$((prev+1))" "$f")
+      prev=$n
+    fi
+    tmux has-session -t "$tn" 2>/dev/null || { _pi_emit session_end; break; }
+    sleep 0.3
+  done
+}
+
+# Stage Pi auth into a per-worker config dir + create the session dir. The spine
+# sets _CSD_CURRENT_WORKER_HOME to <worker_dir>/homes/<tmux_name>.
+harness_prepare() {
+  local tmux_name="$1" cwd="$2" home="$3"
+  mkdir -p "$home/sessions"
+  if [ -d "$HOME/.pi/agent" ]; then
+    cp "$HOME/.pi/agent/auth.json" "$home/" 2>/dev/null || true
+    cp "$HOME/.pi/agent/settings.json" "$home/" 2>/dev/null || true
+  fi
+}
+
+# harness_launch_argv <mode> <sid> <cwd> <plugin_dir> <worker_home>
+# Interactive pi; sessions isolated to the per-worker dir; reproducibility flags.
+harness_launch_argv() {
+  local home="$5"
+  local model="${CSD_PI_MODEL:-openai-codex/gpt-5.5}"
+  printf '%s\n' \
+    "$(harness_bin)" \
+    --session-dir "$home/sessions" \
+    --model "$model" \
+    --no-extensions --no-skills
+}
+
+# PI_CODING_AGENT_DIR (staged auth) + PI_CODING_AGENT_SESSION_DIR (worker sessions).
+harness_env_args() {
+  local home="${_CSD_CURRENT_WORKER_HOME:-}"
+  WORKER_ENV_ARGS=(-e "PI_CODING_AGENT_DIR=${home}" -e "PI_CODING_AGENT_SESSION_DIR=${home}/sessions")
+}
+
+# Start the poller in a second tmux window of the worker's session (dies with it).
+harness_post_launch() {
+  local tmux_name="$1"
+  local sd="${_CSD_CURRENT_WORKER_HOME:-}/sessions"
+  # -d: do NOT switch the active window — cmd_send targets the session's active
+  # window, which must stay pi's (window 0), not the poller's (B1 from review).
+  tmux new-window -d -t "$tmux_name" -n csd-poll \
+    "exec '$CSD_PATH' poll pi '$sd' '$_CSD_WORKER_DIR' '$tmux_name'"
+}
+
+# derive readiness: wait for the pi status bar, else settle (first send re-confirms).
+harness_await_ready() {
+  local tmux_name="$1" deadline=$((SECONDS + 20)) pane
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    pane=$(tmux capture-pane -t "$tmux_name" -p 2>/dev/null || true)
+    echo "$pane" | grep -q 'auto)' && return 0
+    sleep 0.5
+  done
+  return 0
+}
+
+# transcript path recorded by the poller; read from meta.
+harness_transcript_path() {
+  local sid="$1"
+  jq -r '.transcript_path // empty' "$_CSD_WORKER_DIR/${sid}.meta" 2>/dev/null
+}
+
+# Render the last turn of a pi session file as markdown.
+harness_parse_turn() {
+  local sf="$1"
+  [ -f "$sf" ] || { echo "No session at $sf" >&2; return 1; }
+  local start=""
+  start=$(grep -n '"role":"user"' "$sf" | tail -1 | cut -d: -f1) || start=""
+  [ -z "$start" ] && start=1
+  tail -n +"$start" "$sf" | jq -r '
+    select(.type=="message") | .message as $m |
+    if   $m.role=="user"      then "**[user]** " + ([$m.content[]?|select(.type=="text").text]|join(""))+"\n"
+    elif $m.role=="assistant" then
+      ([$m.content[]? |
+        if .type=="text" then .text
+        elif .type=="toolCall" then "\n**Tool: "+.name+"**\n```\n"+(.arguments|tostring)+"\n```"
+        else empty end] | join(""))+"\n"
+    elif $m.role=="toolResult" then "**Result:**\n```\n" + ([$m.content[]?|select(.type=="text").text]|join(""))+"\n```\n"
+    else empty end' 2>/dev/null
+}
+harness_count_text() {
+  local sf="$1" c
+  [ -f "$sf" ] || { echo 0; return; }
+  c=$(grep -c '"role":"assistant"' "$sf" 2>/dev/null) || c=0
+  echo "$c"
+}
+harness_last_text() {
+  local sf="$1"
+  [ -f "$sf" ] || return 0
+  grep '"role":"assistant"' "$sf" \
+    | jq -rs 'map(select(.message.role=="assistant")) | last | [.message.content[]?|select(.type=="text").text]|join("")' 2>/dev/null || true
+}

--- a/tests/fixtures/fake-codex
+++ b/tests/fixtures/fake-codex
@@ -1,12 +1,14 @@
 #!/bin/bash
-# Fake codex for csd tests. Mimics the parts csd drives:
-#  - parses -C <cwd>
-#  - reads $CODEX_HOME/config.toml for the emit-event-codex hook command
+# Fake codex for csd tests (derive control-plane flow, no API). It:
+#  - parses -C <cwd>; reads $CODEX_HOME/config.toml for the emit-event-codex hook
 #  - mints a session id + writes a minimal rollout
-#  - fires the lifecycle hooks with synthetic payloads so emit-event-codex
-#    self-registers <sid>.meta + <sid>.events.jsonl
-#  - prints the trust-gate text (so harness_post_launch's dismissal fires fast)
-#    and the composer glyph (so harness_await_ready returns fast), then stays alive.
+#  - fires a BOOT turn (codex emits one before the controller's first prompt) so
+#    read-turn/status have a completed turn to read
+#  - prints the trust-gate text (fast harness_post_launch) and the composer glyph
+#    (fast harness_await_ready), drains the dismissal keystroke
+#  - then CONFIRMS each submitted prompt (UserPromptSubmit, so csd's send works)
+#    but produces NO new completed turn — letting tests assert that converse waits
+#    for a real new turn rather than echoing the stale boot turn.
 cwd="."
 while [ $# -gt 0 ]; do case "$1" in -C) cwd="$2"; shift 2 ;; *) shift ;; esac; done
 
@@ -22,12 +24,21 @@ HOOKCMD=$(grep -m1 'emit-event-codex' "$CODEX_HOME/config.toml" | sed 's/^comman
 fire(){ printf '{"session_id":"%s","transcript_path":"%s","cwd":"%s","hook_event_name":"%s"%s}' \
   "$SID" "$ROLL" "$cwd" "$1" "${2:-}" | $HOOKCMD; }
 
+# Boot turn.
 fire SessionStart
-fire UserPromptSubmit ',"prompt":"hi"'
+fire UserPromptSubmit ',"prompt":"boot"'
 fire PreToolUse ',"tool_name":"Bash"'
+printf '{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"boot"}]}}\n' >> "$ROLL"
 printf '{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"FAKE_DONE"}]}}\n' >> "$ROLL"
 printf '{"type":"event_msg","payload":{"type":"agent_message","message":"FAKE_DONE"}}\n' >> "$ROLL"
 fire Stop
 
-printf '\xe2\x80\xba\n'   # codex composer glyph, so harness_await_ready returns fast
-exec sleep 60
+printf '\xe2\x80\xba\n'   # composer glyph -> harness_await_ready returns fast
+
+# Drain the trust-gate keystroke (harness_post_launch sends '2' + Enter).
+read -t 2 -r _drain 2>/dev/null || true
+
+# Confirm each submitted prompt but produce NO new completed turn.
+while IFS= read -r _line; do
+  fire UserPromptSubmit ',"prompt":"next"'
+done

--- a/tests/fixtures/fake-codex
+++ b/tests/fixtures/fake-codex
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Fake codex for csd tests. Mimics the parts csd drives:
+#  - parses -C <cwd>
+#  - reads $CODEX_HOME/config.toml for the emit-event-codex hook command
+#  - mints a session id + writes a minimal rollout
+#  - fires the lifecycle hooks with synthetic payloads so emit-event-codex
+#    self-registers <sid>.meta + <sid>.events.jsonl
+#  - prints the trust-gate text (so harness_post_launch's dismissal fires fast)
+#    and the composer glyph (so harness_await_ready returns fast), then stays alive.
+cwd="."
+while [ $# -gt 0 ]; do case "$1" in -C) cwd="$2"; shift 2 ;; *) shift ;; esac; done
+
+echo "Hooks need review (fake-codex)"   # fast-path harness_post_launch
+
+SID="019efake-0000-7000-8000-$(printf '%012d' "$$")"
+DAY=$(date -u +%Y/%m/%d)
+ROLL="$CODEX_HOME/sessions/$DAY/rollout-$(date -u +%Y-%m-%dT%H-%M-%S)-$SID.jsonl"
+mkdir -p "$(dirname "$ROLL")"
+printf '{"type":"session_meta","payload":{"id":"%s","cwd":"%s"}}\n' "$SID" "$cwd" > "$ROLL"
+
+HOOKCMD=$(grep -m1 'emit-event-codex' "$CODEX_HOME/config.toml" | sed 's/^command = "//; s/"$//')
+fire(){ printf '{"session_id":"%s","transcript_path":"%s","cwd":"%s","hook_event_name":"%s"%s}' \
+  "$SID" "$ROLL" "$cwd" "$1" "${2:-}" | $HOOKCMD; }
+
+fire SessionStart
+fire UserPromptSubmit ',"prompt":"hi"'
+fire PreToolUse ',"tool_name":"Bash"'
+printf '{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"FAKE_DONE"}]}}\n' >> "$ROLL"
+printf '{"type":"event_msg","payload":{"type":"agent_message","message":"FAKE_DONE"}}\n' >> "$ROLL"
+fire Stop
+
+printf '\xe2\x80\xba\n'   # codex composer glyph, so harness_await_ready returns fast
+exec sleep 60

--- a/tests/fixtures/fake-pi
+++ b/tests/fixtures/fake-pi
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Fake pi for csd tests (no API). Writes a session JSONL (boot turn) under the
+# per-worker session dir, prints the status-bar glyph (for harness_await_ready),
+# then confirms each submitted prompt with a fresh `user` record (so the poller
+# emits user_prompt_submit and csd's send-confirmation succeeds) but produces NO
+# new completed turn — so a correct converse waits instead of echoing the stale
+# boot turn (multi-turn regression, mirroring fake-codex).
+sd="${PI_CODING_AGENT_SESSION_DIR:-.}"
+while [ $# -gt 0 ]; do case "$1" in --session-dir) sd="$2"; shift 2 ;; *) shift ;; esac; done
+mkdir -p "$sd"
+SID="019efake-0000-7000-8000-$(printf '%012d' "$$")"
+SF="$sd/2026-01-01T00-00-00-000Z_${SID}.jsonl"
+{
+  printf '{"type":"session","version":3,"id":"%s","cwd":"."}\n' "$SID"
+  printf '{"type":"message","message":{"role":"user","content":[{"type":"text","text":"boot"}]}}\n'
+  printf '{"type":"message","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"FAKE_PI_DONE"}]}}\n'
+} > "$SF"
+
+echo "0.0%/272k (auto)"   # status bar -> harness_await_ready returns fast
+
+while IFS= read -r _line; do
+  printf '{"type":"message","message":{"role":"user","content":[{"type":"text","text":"next"}]}}\n' >> "$SF"
+done

--- a/tests/smoke-codex-real.sh
+++ b/tests/smoke-codex-real.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+# Real-codex end-to-end smoke: drives an actual Codex worker through csd.
+# Gated — costs a real subscription turn. Needs ~/.codex/auth.json + consent.
+#   CSD_RUN_REAL_CODEX=1 bash tests/smoke-codex-real.sh
+[ -n "${CSD_RUN_REAL_CODEX:-}" ] || { echo "Set CSD_RUN_REAL_CODEX=1 to run (uses a real codex subscription turn)."; exit 0; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
+# Self-contained HOME: staged consent + a copy of the real codex auth, so the
+# smoke doesn't require `csd grant-consent` and never touches the real ~/.claude.
+REAL_CODEX_AUTH="$HOME/.codex/auth.json"
+SHOME=$(mktemp -d); mkdir -p "$SHOME/.claude" "$SHOME/.codex"
+touch "$SHOME/.claude/.claude-session-driver-consent"
+[ -f "$REAL_CODEX_AUTH" ] && cp "$REAL_CODEX_AUTH" "$SHOME/.codex/auth.json"
+export HOME="$SHOME"
+WDIR=$(mktemp -d); WD=$(mktemp -d); TN="smoke-codex-$$"
+export CSD_WORKER_DIR="$WDIR"
+cleanup(){ "$CSD" --worker "$TN" stop >/dev/null 2>&1 || true; tmux kill-session -t "$TN" 2>/dev/null || true; rm -rf "$WDIR" "$WD" "$SHOME"; }
+trap cleanup EXIT
+
+echo "[smoke] launching real codex worker $TN in $WD ..."
+SHIM=$("$CSD" launch --harness codex "$TN" "$WD")
+echo "[smoke] shim: $SHIM"
+
+echo "[smoke] conversing (real turn) ..."
+OUT=$("$CSD" --worker "$TN" converse "Run the bash command: echo SMOKE_OK_CODEX . Then reply with exactly the word DONE." 240)
+echo "[smoke] === converse response ==="
+echo "$OUT"
+echo "[smoke] === read-turn ==="
+"$CSD" --worker "$TN" read-turn || true
+
+if echo "$OUT" | grep -qiE 'done|smoke_ok'; then
+  echo "[smoke] PASS — real Codex worker drove a turn through csd"
+else
+  echo "[smoke] FAIL — unexpected response"; exit 1
+fi

--- a/tests/smoke-codex-real.sh
+++ b/tests/smoke-codex-real.sh
@@ -23,15 +23,17 @@ echo "[smoke] launching real codex worker $TN in $WD ..."
 SHIM=$("$CSD" launch --harness codex "$TN" "$WD")
 echo "[smoke] shim: $SHIM"
 
-echo "[smoke] conversing (real turn) ..."
-OUT=$("$CSD" --worker "$TN" converse "Run the bash command: echo SMOKE_OK_CODEX . Then reply with exactly the word DONE." 240)
-echo "[smoke] === converse response ==="
-echo "$OUT"
+echo "[smoke] turn 1 ..."
+OUT1=$("$CSD" --worker "$TN" converse "Reply with exactly the word ALPHA and nothing else." 240)
+echo "[smoke] turn 1 response: $OUT1"
+echo "[smoke] turn 2 (multi-turn — must NOT return turn 1's answer) ..."
+OUT2=$("$CSD" --worker "$TN" converse "Reply with exactly the word BRAVO and nothing else." 240)
+echo "[smoke] turn 2 response: $OUT2"
 echo "[smoke] === read-turn ==="
 "$CSD" --worker "$TN" read-turn || true
 
-if echo "$OUT" | grep -qiE 'done|smoke_ok'; then
-  echo "[smoke] PASS — real Codex worker drove a turn through csd"
+if echo "$OUT1" | grep -qi 'alpha' && echo "$OUT2" | grep -qi 'bravo' && ! echo "$OUT2" | grep -qi 'alpha'; then
+  echo "[smoke] PASS — real Codex multi-turn conversation through csd (turn 2 != stale turn 1)"
 else
-  echo "[smoke] FAIL — unexpected response"; exit 1
+  echo "[smoke] FAIL — turn1='$OUT1' turn2='$OUT2'"; exit 1
 fi

--- a/tests/smoke-pi-real.sh
+++ b/tests/smoke-pi-real.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+# Real-pi end-to-end multi-turn smoke: drives an actual Pi worker through csd.
+# Gated — costs real subscription turns. Needs ~/.pi/agent (auth) + the pi binary.
+#   CSD_RUN_REAL_PI=1 bash tests/smoke-pi-real.sh
+[ -n "${CSD_RUN_REAL_PI:-}" ] || { echo "Set CSD_RUN_REAL_PI=1 to run (uses real pi subscription turns)."; exit 0; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
+REAL_HOME="$HOME"
+PI="${CSD_PI_BIN:-$(command -v pi 2>/dev/null || ls "$REAL_HOME"/.local/share/mise/installs/pi/*/pi 2>/dev/null | head -1)}"
+[ -n "$PI" ] && [ -x "$PI" ] || { echo "pi binary not found; set CSD_PI_BIN to its path."; exit 0; }
+
+# Self-contained HOME: staged consent + a copy of the real ~/.pi/agent (auth).
+SHOME=$(mktemp -d); mkdir -p "$SHOME/.claude" "$SHOME/.pi"
+touch "$SHOME/.claude/.claude-session-driver-consent"
+[ -d "$REAL_HOME/.pi/agent" ] && cp -R "$REAL_HOME/.pi/agent" "$SHOME/.pi/agent"
+export HOME="$SHOME" CSD_PI_BIN="$PI"
+WDIR=$(mktemp -d); WD=$(mktemp -d); TN="smoke-pi-$$"
+export CSD_WORKER_DIR="$WDIR"
+cleanup(){ "$CSD" --worker "$TN" stop >/dev/null 2>&1 || true; tmux kill-session -t "$TN" 2>/dev/null || true; rm -rf "$WDIR" "$WD" "$SHOME"; }
+trap cleanup EXIT
+
+echo "[smoke] launching real pi worker $TN ($PI) ..."
+SHIM=$("$CSD" launch --harness pi "$TN" "$WD")
+echo "[smoke] shim: $SHIM"
+
+echo "[smoke] turn 1 ..."
+OUT1=$("$CSD" --worker "$TN" converse "Reply with exactly the word ALPHA and nothing else." 180)
+echo "[smoke] turn 1 response: $OUT1"
+echo "[smoke] turn 2 (multi-turn — must NOT return turn 1's answer) ..."
+OUT2=$("$CSD" --worker "$TN" converse "Reply with exactly the word BRAVO and nothing else." 180)
+echo "[smoke] turn 2 response: $OUT2"
+echo "[smoke] === read-turn ==="
+"$CSD" --worker "$TN" read-turn || true
+
+if echo "$OUT1" | grep -qi 'alpha' && echo "$OUT2" | grep -qi 'bravo' && ! echo "$OUT2" | grep -qi 'alpha'; then
+  echo "[smoke] PASS — real Pi multi-turn conversation through csd (turn 2 != stale turn 1)"
+else
+  echo "[smoke] FAIL — turn1='$OUT1' turn2='$OUT2'"; exit 1
+fi

--- a/tests/test-csd-adopt.sh
+++ b/tests/test-csd-adopt.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -46,9 +46,9 @@ while [ $# -gt 0 ]; do
     *) shift ;;
   esac
 done
-mkdir -p /tmp/claude-workers
+mkdir -p /tmp/csd-workers
 echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"event\":\"session_start\",\"cwd\":\"$PWD\"}" \
-  > "/tmp/claude-workers/${SID}.events.jsonl"
+  > "/tmp/csd-workers/${SID}.events.jsonl"
 exec sleep 60
 BASH
 chmod +x "$FAKE_CLAUDE"

--- a/tests/test-csd-codex.sh
+++ b/tests/test-csd-codex.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCR="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts"
+PASS=0; FAIL=0
+pass(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail(){ echo "  FAIL: $1 - $2"; FAIL=$((FAIL+1)); }
+probe(){ ( source "$SCR/_lib.sh"; _load_driver codex; "$@" ); }
+
+# --- manifest ---
+[ "$(probe harness_id)" = "codex" ] && pass "id=codex" || fail "id" "wrong"
+[ "$(probe harness_control_plane)" = "hooks" ] && pass "control_plane=hooks" || fail "cp" "wrong"
+[ "$(probe harness_id_strategy)" = "derive" ] && pass "id_strategy=derive" || fail "ids" "wrong"
+[ "$(probe harness_quit_keys)" = "/quit" ] && pass "quit=/quit" || fail "quit" "wrong"
+[ "$(probe harness_bin)" = "codex" ] && pass "bin=codex" || fail "bin" "wrong"
+
+# --- prepare writes the per-worker config (HOME=/nonexistent skips auth copy) ---
+HOME_DIR=$(mktemp -d); CWD=$(mktemp -d)
+( source "$SCR/_lib.sh"; _load_driver codex; CSD_PLUGIN_DIR=/plug HOME=/nonexistent harness_prepare wkr "$CWD" "$HOME_DIR" )
+[ -f "$HOME_DIR/config.toml" ] && pass "config.toml written" || fail "config" "missing"
+grep -q "emit-event-codex wkr $CWD" "$HOME_DIR/config.toml" && pass "hook bakes tmux_name+cwd+workerdir" || fail "hook args" "missing"
+grep -q '\[\[hooks.SessionStart\]\]' "$HOME_DIR/config.toml" && pass "SessionStart hook registered" || fail "sshook" "missing"
+grep -q 'trust_level' "$HOME_DIR/config.toml" && pass "project trust" || fail "trust" "missing"
+
+# --- launch argv: no --session-id; -C <cwd> + bypass flags ---
+av=$( ( source "$SCR/_lib.sh"; _load_driver codex; harness_launch_argv launch "" "$CWD" /plug "$HOME_DIR" ) )
+echo "$av" | grep -qx -- "--dangerously-bypass-approvals-and-sandbox" && pass "yolo flag" || fail "yolo" "missing"
+echo "$av" | grep -qx -- "--session-id" && fail "no sid" "should be absent" || pass "no --session-id"
+echo "$av" | grep -qx -- "-C" && pass "-C cwd flag" || fail "-C" "missing"
+
+# --- env_args: CODEX_HOME, set -u safe when worker home unset ---
+ea=$( ( source "$SCR/_lib.sh"; _load_driver codex; WORKER_ENV_ARGS=(); harness_env_args; printf '%s\n' "${WORKER_ENV_ARGS[@]}" ) )
+echo "$ea" | grep -q '^CODEX_HOME=' && pass "env CODEX_HOME (set -u safe)" || fail "env" "missing: $ea"
+
+# --- parse_turn renders a minimal rollout ---
+ROLL=$(mktemp)
+printf '%s\n' \
+  '{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}' \
+  '{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"HELLO_CDX"}]}}' > "$ROLL"
+out=$( ( source "$SCR/_lib.sh"; _load_driver codex; harness_parse_turn "$ROLL" ) )
+echo "$out" | grep -q "HELLO_CDX" && pass "parse_turn renders assistant text" || fail "parse" "got: $out"
+
+# --- count_text is single-valued on no-match (B4) ---
+ct=$( ( source "$SCR/_lib.sh"; _load_driver codex; harness_count_text "$ROLL" ) )
+[ "$ct" = "0" ] && pass "count_text single 0 on no agent_message" || fail "count" "got: [$ct]"
+
+rm -rf "$HOME_DIR" "$CWD" "$ROLL"
+echo "codex-driver: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/tests/test-csd-codex.sh
+++ b/tests/test-csd-codex.sh
@@ -60,6 +60,11 @@ ST=$(run_csd --worker "$ITN" status 2>/dev/null || true)
 # meta self-registered with harness=codex
 M=$(ls "$IWDIR"/*.meta 2>/dev/null | head -1)
 [ -n "$M" ] && [ "$(jq -r '.harness' "$M")" = "codex" ] && pass "codex meta self-registered" || fail "codex meta" "missing/wrong"
+# Multi-turn safety (regression for the derive after_line/before_count bug):
+# the worker confirms the prompt but produces no NEW completed turn, so a correct
+# converse must keep waiting and NOT echo the stale boot turn's answer.
+OUT2=$(run_csd --worker "$ITN" converse "again please" 4 2>/dev/null || true)
+echo "$OUT2" | grep -q FAKE_DONE && fail "converse stale-turn" "echoed the prior turn: $OUT2" || pass "converse waits for a new turn (no stale answer)"
 run_csd --worker "$ITN" stop >/dev/null 2>&1 || true
 tmux kill-session -t "$ITN" 2>/dev/null || true
 rm -rf "$IHOME" "$IWD" "$IWDIR"

--- a/tests/test-csd-codex.sh
+++ b/tests/test-csd-codex.sh
@@ -45,4 +45,23 @@ ct=$( ( source "$SCR/_lib.sh"; _load_driver codex; harness_count_text "$ROLL" ) 
 [ "$ct" = "0" ] && pass "count_text single 0 on no agent_message" || fail "count" "got: [$ct]"
 
 rm -rf "$HOME_DIR" "$CWD" "$ROLL"
+
+# --- integration: fake-codex launch -> self-register -> read-turn -> status ---
+FAKE="$SCRIPT_DIR/fixtures/fake-codex"; chmod +x "$FAKE" 2>/dev/null || true
+IHOME=$(mktemp -d); mkdir -p "$IHOME/.claude"; touch "$IHOME/.claude/.claude-session-driver-consent"
+IWDIR=$(mktemp -d); ITN="test-codex-$$"; IWD=$(mktemp -d)
+run_csd(){ CSD_WORKER_DIR="$IWDIR" CSD_CODEX_BIN="$FAKE" HOME="$IHOME" bash "$SCR/csd" "$@"; }
+run_csd launch --harness codex "$ITN" "$IWD" >/dev/null 2>&1 || true
+sleep 1
+OUT=$(run_csd --worker "$ITN" read-turn 2>/dev/null || true)
+echo "$OUT" | grep -q "FAKE_DONE" && pass "codex read-turn renders the turn" || fail "codex read-turn" "got: $OUT"
+ST=$(run_csd --worker "$ITN" status 2>/dev/null || true)
+[ "$ST" = "idle" ] && pass "codex status idle after stop event" || fail "codex status" "got: $ST"
+# meta self-registered with harness=codex
+M=$(ls "$IWDIR"/*.meta 2>/dev/null | head -1)
+[ -n "$M" ] && [ "$(jq -r '.harness' "$M")" = "codex" ] && pass "codex meta self-registered" || fail "codex meta" "missing/wrong"
+run_csd --worker "$ITN" stop >/dev/null 2>&1 || true
+tmux kill-session -t "$ITN" 2>/dev/null || true
+rm -rf "$IHOME" "$IWD" "$IWDIR"
+
 echo "codex-driver: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/tests/test-csd-converse-diag.sh
+++ b/tests/test-csd-converse-diag.sh
@@ -6,7 +6,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS=0
 FAIL=0

--- a/tests/test-csd-converse.sh
+++ b/tests/test-csd-converse.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0

--- a/tests/test-csd-drivers.sh
+++ b/tests/test-csd-drivers.sh
@@ -40,17 +40,17 @@ META_HOME=$(mktemp -d); mkdir -p "$META_HOME/.claude"; touch "$META_HOME/.claude
 META_FAKE=$(mktemp); cat > "$META_FAKE" <<'B'
 #!/bin/bash
 SID=""; while [ $# -gt 0 ]; do case "$1" in --session-id) SID="$2"; shift 2;; *) shift;; esac; done
-mkdir -p /tmp/claude-workers
-echo "{\"ts\":\"x\",\"event\":\"session_start\",\"cwd\":\"$PWD\"}" > "/tmp/claude-workers/${SID}.events.jsonl"; exec sleep 30
+mkdir -p /tmp/csd-workers
+echo "{\"ts\":\"x\",\"event\":\"session_start\",\"cwd\":\"$PWD\"}" > "/tmp/csd-workers/${SID}.events.jsonl"; exec sleep 30
 B
 chmod +x "$META_FAKE"
 META_TN="test-drivers-meta-$$"
 CSD_CLAUDE_BIN="$META_FAKE" HOME="$META_HOME" bash "$SCR/csd" launch "$META_TN" /tmp >/dev/null 2>&1 || true
 META=""
-for m in /tmp/claude-workers/*.meta; do [ -f "$m" ] || continue; [ "$(jq -r '.tmux_name' "$m" 2>/dev/null)" = "$META_TN" ] && META="$m" && break; done
+for m in /tmp/csd-workers/*.meta; do [ -f "$m" ] || continue; [ "$(jq -r '.tmux_name' "$m" 2>/dev/null)" = "$META_TN" ] && META="$m" && break; done
 if [ -n "$META" ] && [ "$(jq -r '.harness' "$META")" = "claude" ]; then pass "meta records harness=claude"; else fail "meta harness" "got ${META:+$(jq -r '.harness' "$META" 2>/dev/null)}"; fi
 tmux kill-session -t "$META_TN" 2>/dev/null || true
-[ -n "$META" ] && { SID=$(basename "$META" .meta); rm -f "/tmp/claude-workers/$SID".* "/tmp/claude-workers/bin/$META_TN"; }
+[ -n "$META" ] && { SID=$(basename "$META" .meta); rm -f "/tmp/csd-workers/$SID".* "/tmp/csd-workers/bin/$META_TN"; }
 rm -rf "$META_HOME" "$META_FAKE"
 
 echo "drivers: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/tests/test-csd-drivers.sh
+++ b/tests/test-csd-drivers.sh
@@ -15,13 +15,13 @@ probe() { ( source "$SCR/_lib.sh"; _load_driver claude; "$@" ); }
 [ "$(CSD_CLAUDE_BIN=/x/claude probe harness_bin)" = "/x/claude" ] && pass "bin honors CSD_CLAUDE_BIN" || fail "bin override" "wrong"
 if ( source "$SCR/_lib.sh"; _load_driver nope ) 2>/dev/null; then fail "unknown driver" "should fail"; else pass "unknown driver errors"; fi
 
-argv_launch=$( ( source "$SCR/_lib.sh"; _load_driver claude; harness_launch_argv launch SID123 /plug ) )
+argv_launch=$( ( source "$SCR/_lib.sh"; _load_driver claude; harness_launch_argv launch SID123 /cwd /plug /home ) )
 [ "$(echo "$argv_launch" | head -1)" = "claude" ] && pass "launch argv starts with bin" || fail "launch argv bin" "wrong"
 echo "$argv_launch" | grep -qx -- "--session-id" && echo "$argv_launch" | grep -qx "SID123" && pass "launch uses --session-id" || fail "launch sid" "wrong"
 echo "$argv_launch" | grep -qx -- "--dangerously-skip-permissions" && pass "launch bypass flag" || fail "bypass" "wrong"
 echo "$argv_launch" | grep -qx "AskUserQuestion" && pass "launch disallows AskUserQuestion" || fail "disallow" "wrong"
 echo "$argv_launch" | grep -qFx '{"skipDangerousModePermissionPrompt":true}' && pass "settings is one token" || fail "settings token" "split"
-argv_resume=$( ( source "$SCR/_lib.sh"; _load_driver claude; harness_launch_argv resume SID123 /plug ) )
+argv_resume=$( ( source "$SCR/_lib.sh"; _load_driver claude; harness_launch_argv resume SID123 /cwd /plug /home ) )
 echo "$argv_resume" | grep -qx -- "--resume" && pass "resume uses --resume" || fail "resume" "wrong"
 echo "$argv_resume" | grep -qx -- "--session-id" && fail "resume sid" "should not use --session-id" || pass "resume omits --session-id"
 

--- a/tests/test-csd-drivers.sh
+++ b/tests/test-csd-drivers.sh
@@ -35,4 +35,22 @@ echo "$out2" | grep -qx "CLAUDE_CODE_USE_BEDROCK=" && fail "env set-bedrock" "sh
 tp=$( ( source "$SCR/_lib.sh"; _load_driver claude; HOME=/home/x harness_transcript_path SID /a/b ) )
 [ "$tp" = "/home/x/.claude/projects/-a-b/SID.jsonl" ] && pass "transcript_path formula" || fail "transcript_path" "got $tp"
 
+# After a launch, the meta records harness=claude (back-compat default).
+META_HOME=$(mktemp -d); mkdir -p "$META_HOME/.claude"; touch "$META_HOME/.claude/.claude-session-driver-consent"
+META_FAKE=$(mktemp); cat > "$META_FAKE" <<'B'
+#!/bin/bash
+SID=""; while [ $# -gt 0 ]; do case "$1" in --session-id) SID="$2"; shift 2;; *) shift;; esac; done
+mkdir -p /tmp/claude-workers
+echo "{\"ts\":\"x\",\"event\":\"session_start\",\"cwd\":\"$PWD\"}" > "/tmp/claude-workers/${SID}.events.jsonl"; exec sleep 30
+B
+chmod +x "$META_FAKE"
+META_TN="test-drivers-meta-$$"
+CSD_CLAUDE_BIN="$META_FAKE" HOME="$META_HOME" bash "$SCR/csd" launch "$META_TN" /tmp >/dev/null 2>&1 || true
+META=""
+for m in /tmp/claude-workers/*.meta; do [ -f "$m" ] || continue; [ "$(jq -r '.tmux_name' "$m" 2>/dev/null)" = "$META_TN" ] && META="$m" && break; done
+if [ -n "$META" ] && [ "$(jq -r '.harness' "$META")" = "claude" ]; then pass "meta records harness=claude"; else fail "meta harness" "got ${META:+$(jq -r '.harness' "$META" 2>/dev/null)}"; fi
+tmux kill-session -t "$META_TN" 2>/dev/null || true
+[ -n "$META" ] && { SID=$(basename "$META" .meta); rm -f "/tmp/claude-workers/$SID".* "/tmp/claude-workers/bin/$META_TN"; }
+rm -rf "$META_HOME" "$META_FAKE"
+
 echo "drivers: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/tests/test-csd-drivers.sh
+++ b/tests/test-csd-drivers.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCR="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts"
+PASS=0; FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1 - $2"; FAIL=$((FAIL+1)); }
+probe() { ( source "$SCR/_lib.sh"; _load_driver claude; "$@" ); }
+
+[ "$(probe harness_id)" = "claude" ] && pass "harness_id=claude" || fail "harness_id" "got $(probe harness_id)"
+[ "$(probe harness_control_plane)" = "hooks" ] && pass "control_plane=hooks" || fail "control_plane" "wrong"
+[ "$(probe harness_id_strategy)" = "assign" ] && pass "id_strategy=assign" || fail "id_strategy" "wrong"
+[ "$(probe harness_quit_keys)" = "/exit" ] && pass "quit_keys=/exit" || fail "quit_keys" "wrong"
+[ "$(probe harness_bin)" = "claude" ] && pass "bin defaults to claude" || fail "bin" "wrong"
+[ "$(CSD_CLAUDE_BIN=/x/claude probe harness_bin)" = "/x/claude" ] && pass "bin honors CSD_CLAUDE_BIN" || fail "bin override" "wrong"
+if ( source "$SCR/_lib.sh"; _load_driver nope ) 2>/dev/null; then fail "unknown driver" "should fail"; else pass "unknown driver errors"; fi
+
+echo "drivers: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/tests/test-csd-drivers.sh
+++ b/tests/test-csd-drivers.sh
@@ -32,4 +32,7 @@ echo "$out" | grep -qx "CLAUDE_CODE_USE_BEDROCK=" && pass "env: unset bedrock pi
 out2=$(CLAUDE_CODE_USE_BEDROCK=1 envprobe true)
 echo "$out2" | grep -qx "CLAUDE_CODE_USE_BEDROCK=" && fail "env set-bedrock" "should NOT pin a set var" || pass "env: set bedrock left to inherit"
 
+tp=$( ( source "$SCR/_lib.sh"; _load_driver claude; HOME=/home/x harness_transcript_path SID /a/b ) )
+[ "$tp" = "/home/x/.claude/projects/-a-b/SID.jsonl" ] && pass "transcript_path formula" || fail "transcript_path" "got $tp"
+
 echo "drivers: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/tests/test-csd-drivers.sh
+++ b/tests/test-csd-drivers.sh
@@ -15,4 +15,11 @@ probe() { ( source "$SCR/_lib.sh"; _load_driver claude; "$@" ); }
 [ "$(CSD_CLAUDE_BIN=/x/claude probe harness_bin)" = "/x/claude" ] && pass "bin honors CSD_CLAUDE_BIN" || fail "bin override" "wrong"
 if ( source "$SCR/_lib.sh"; _load_driver nope ) 2>/dev/null; then fail "unknown driver" "should fail"; else pass "unknown driver errors"; fi
 
+envprobe() { ( source "$SCR/_lib.sh"; _load_driver claude; "$@"; harness_env_args; printf '%s\n' "${WORKER_ENV_ARGS[@]}" ); }
+out=$(unset CLAUDE_CODE_USE_BEDROCK; envprobe true)
+echo "$out" | grep -qx "CLAUDE_CODE_SSE_PORT=" && pass "env: SSE_PORT pinned" || fail "env SSE_PORT" "missing"
+echo "$out" | grep -qx "CLAUDE_CODE_USE_BEDROCK=" && pass "env: unset bedrock pinned empty" || fail "env bedrock unset" "missing"
+out2=$(CLAUDE_CODE_USE_BEDROCK=1 envprobe true)
+echo "$out2" | grep -qx "CLAUDE_CODE_USE_BEDROCK=" && fail "env set-bedrock" "should NOT pin a set var" || pass "env: set bedrock left to inherit"
+
 echo "drivers: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/tests/test-csd-drivers.sh
+++ b/tests/test-csd-drivers.sh
@@ -15,6 +15,16 @@ probe() { ( source "$SCR/_lib.sh"; _load_driver claude; "$@" ); }
 [ "$(CSD_CLAUDE_BIN=/x/claude probe harness_bin)" = "/x/claude" ] && pass "bin honors CSD_CLAUDE_BIN" || fail "bin override" "wrong"
 if ( source "$SCR/_lib.sh"; _load_driver nope ) 2>/dev/null; then fail "unknown driver" "should fail"; else pass "unknown driver errors"; fi
 
+argv_launch=$( ( source "$SCR/_lib.sh"; _load_driver claude; harness_launch_argv launch SID123 /plug ) )
+[ "$(echo "$argv_launch" | head -1)" = "claude" ] && pass "launch argv starts with bin" || fail "launch argv bin" "wrong"
+echo "$argv_launch" | grep -qx -- "--session-id" && echo "$argv_launch" | grep -qx "SID123" && pass "launch uses --session-id" || fail "launch sid" "wrong"
+echo "$argv_launch" | grep -qx -- "--dangerously-skip-permissions" && pass "launch bypass flag" || fail "bypass" "wrong"
+echo "$argv_launch" | grep -qx "AskUserQuestion" && pass "launch disallows AskUserQuestion" || fail "disallow" "wrong"
+echo "$argv_launch" | grep -qFx '{"skipDangerousModePermissionPrompt":true}' && pass "settings is one token" || fail "settings token" "split"
+argv_resume=$( ( source "$SCR/_lib.sh"; _load_driver claude; harness_launch_argv resume SID123 /plug ) )
+echo "$argv_resume" | grep -qx -- "--resume" && pass "resume uses --resume" || fail "resume" "wrong"
+echo "$argv_resume" | grep -qx -- "--session-id" && fail "resume sid" "should not use --session-id" || pass "resume omits --session-id"
+
 envprobe() { ( source "$SCR/_lib.sh"; _load_driver claude; "$@"; harness_env_args; printf '%s\n' "${WORKER_ENV_ARGS[@]}" ); }
 out=$(unset CLAUDE_CODE_USE_BEDROCK; envprobe true)
 echo "$out" | grep -qx "CLAUDE_CODE_SSE_PORT=" && pass "env: SSE_PORT pinned" || fail "env SSE_PORT" "missing"

--- a/tests/test-csd-handoff.sh
+++ b/tests/test-csd-handoff.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0

--- a/tests/test-csd-integration.sh
+++ b/tests/test-csd-integration.sh
@@ -17,12 +17,12 @@ touch "$FAKE_HOME/.claude/.claude-session-driver-consent"
 
 cleanup() {
   tmux kill-session -t "$TMUX_NAME" 2>/dev/null || true
-  rm -f /tmp/claude-workers/bin/"$TMUX_NAME"
-  for f in /tmp/claude-workers/*.meta; do
+  rm -f /tmp/csd-workers/bin/"$TMUX_NAME"
+  for f in /tmp/csd-workers/*.meta; do
     [ -f "$f" ] || continue
     if jq -e --arg n "$TMUX_NAME" '.tmux_name == $n' "$f" >/dev/null 2>&1; then
       sid=$(jq -r '.session_id' "$f")
-      rm -f "$f" "/tmp/claude-workers/${sid}.events.jsonl"
+      rm -f "$f" "/tmp/csd-workers/${sid}.events.jsonl"
     fi
   done
 }
@@ -39,9 +39,9 @@ while [ $# -gt 0 ]; do
     *) shift ;;
   esac
 done
-mkdir -p /tmp/claude-workers
+mkdir -p /tmp/csd-workers
 echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"event\":\"session_start\",\"cwd\":\"$PWD\"}" \
-  > "/tmp/claude-workers/${SID}.events.jsonl"
+  > "/tmp/csd-workers/${SID}.events.jsonl"
 exec sleep 60
 BASH
 chmod +x "$FAKE_CLAUDE"
@@ -56,7 +56,7 @@ STATUS=$("$SHIM" status)
 
 # session-id via shim matches meta
 SID_VIA_SHIM=$("$SHIM" session-id)
-META=$(ls /tmp/claude-workers/*.meta | xargs grep -l "$TMUX_NAME" | head -1)
+META=$(ls /tmp/csd-workers/*.meta | xargs grep -l "$TMUX_NAME" | head -1)
 SID_IN_META=$(jq -r '.session_id' "$META")
 [ "$SID_VIA_SHIM" = "$SID_IN_META" ] && pass "session-id matches" || fail "sid" "shim=$SID_VIA_SHIM meta=$SID_IN_META"
 

--- a/tests/test-csd-launch.sh
+++ b/tests/test-csd-launch.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -24,7 +24,7 @@ mkdir -p "$WDIR" "$WDIR/bin" "$FAKE_HOME/.claude"
 touch "$FAKE_HOME/.claude/.claude-session-driver-consent"
 
 # Use the harness's existing fake-claude trick: launch points at a /bin/sh that
-# emits session_start by writing to /tmp/claude-workers/<sid>.events.jsonl.
+# emits session_start by writing to /tmp/csd-workers/<sid>.events.jsonl.
 # We need the session_id, so we wrap a tiny helper that the test injects via
 # the test-mode flag --test-claude-cmd.
 
@@ -41,9 +41,9 @@ while [ $# -gt 0 ]; do
     *) shift ;;
   esac
 done
-mkdir -p /tmp/claude-workers
+mkdir -p /tmp/csd-workers
 echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"event\":\"session_start\",\"cwd\":\"$PWD\"}" \
-  > "/tmp/claude-workers/${SID}.events.jsonl"
+  > "/tmp/csd-workers/${SID}.events.jsonl"
 # Stay alive so tmux session persists
 exec sleep 60
 BASH
@@ -52,7 +52,7 @@ chmod +x "$FAKE_CLAUDE"
 OUTPUT=$(CSD_CLAUDE_BIN="$FAKE_CLAUDE" HOME="$FAKE_HOME" \
          bash "$CSD" launch "$TMUX_NAME" /tmp -- --model sonnet 2>/tmp/launch-stderr-$$)
 STDERR=$(cat /tmp/launch-stderr-$$ || true); rm -f /tmp/launch-stderr-$$
-EXPECTED_SHIM="/tmp/claude-workers/bin/$TMUX_NAME"
+EXPECTED_SHIM="/tmp/csd-workers/bin/$TMUX_NAME"
 
 # stdout is exactly the shim path
 if [ "$OUTPUT" = "$EXPECTED_SHIM" ]; then

--- a/tests/test-csd-list.sh
+++ b/tests/test-csd-list.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -41,7 +41,7 @@ if echo "$OUTPUT" | grep -q "test-list-dead"; then
 else
   pass "gone worker excluded by default"
 fi
-if echo "$OUTPUT" | grep -q "/tmp/claude-workers/bin/test-list-alive"; then
+if echo "$OUTPUT" | grep -q "/tmp/csd-workers/bin/test-list-alive"; then
   pass "shim path included in output"
 else
   fail "shim path" "expected shim path in row, got: $OUTPUT"

--- a/tests/test-csd-pi.sh
+++ b/tests/test-csd-pi.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCR="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts"
+PASS=0; FAIL=0
+pass(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail(){ echo "  FAIL: $1 - $2"; FAIL=$((FAIL+1)); }
+probe(){ ( source "$SCR/_lib.sh"; _load_driver pi; "$@" ); }
+
+# --- manifest ---
+[ "$(probe harness_id)" = "pi" ] && pass "id=pi" || fail "id" "wrong"
+[ "$(probe harness_control_plane)" = "poll" ] && pass "control_plane=poll" || fail "cp" "wrong"
+[ "$(probe harness_id_strategy)" = "derive" ] && pass "id_strategy=derive" || fail "ids" "wrong"
+[ "$(probe harness_quit_keys)" = "/quit" ] && pass "quit=/quit" || fail "quit" "wrong"
+
+# --- harness_poll self-registers the meta + synthesizes events ---
+SD=$(mktemp -d); WDIR=$(mktemp -d)
+SID="019e0000-0000-7000-8000-0000000000aa"
+SF="$SD/2026-01-01T00-00-00-000Z_${SID}.jsonl"
+{
+  printf '{"type":"session","version":3,"id":"%s","cwd":"/w"}\n' "$SID"
+  printf '{"type":"message","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}\n'
+  printf '{"type":"message","message":{"role":"assistant","stopReason":"toolUse","content":[{"type":"toolCall","name":"bash","arguments":{"command":"echo x"}}]}}\n'
+  printf '{"type":"message","message":{"role":"toolResult","toolName":"bash","content":[{"type":"text","text":"x"}]}}\n'
+  printf '{"type":"message","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"PI_ANSWER"}]}}\n'
+} > "$SF"
+( source "$SCR/_lib.sh"; _load_driver pi; harness_poll "$SD" "$WDIR" "no-such-tmux-$$" ) >/dev/null 2>&1 || true
+M=$(ls "$WDIR"/*.meta 2>/dev/null | head -1)
+[ -n "$M" ] && [ "$(jq -r '.harness' "$M")" = "pi" ] && pass "poller self-registers pi meta" || fail "meta" "missing"
+[ -n "$M" ] && [ "$(jq -r '.session_id' "$M")" = "$SID" ] && pass "meta has session id from line 1" || fail "sid" "wrong"
+EV="${M%.meta}.events.jsonl"
+ev_seq=$(jq -r '.event' "$EV" 2>/dev/null | tr '\n' ',')
+echo "$ev_seq" | grep -q 'session_start,user_prompt_submit,pre_tool_use,post_tool_use,stop' && pass "poller synthesizes the event sequence" || fail "events" "got $ev_seq"
+rm -rf "$SD" "$WDIR"
+
+# --- prepare + launch + env slots ---
+HOME_DIR=$(mktemp -d); CWD=$(mktemp -d)
+( source "$SCR/_lib.sh"; _load_driver pi; CSD_PLUGIN_DIR=/plug HOME=/nonexistent harness_prepare wkr "$CWD" "$HOME_DIR" )
+[ -d "$HOME_DIR/sessions" ] && pass "pi session dir created" || fail "session dir" "missing"
+av=$( ( source "$SCR/_lib.sh"; _load_driver pi; harness_launch_argv launch "" "$CWD" /plug "$HOME_DIR" ) )
+echo "$av" | grep -qx -- "--session-dir" && pass "pi --session-dir" || fail "--session-dir" "missing"
+echo "$av" | grep -qx -- "--session-id" && fail "no sid" "should be absent" || pass "no --session-id"
+ea=$( ( source "$SCR/_lib.sh"; _load_driver pi; WORKER_ENV_ARGS=(); harness_env_args; printf '%s\n' "${WORKER_ENV_ARGS[@]}" ) )
+echo "$ea" | grep -q '^PI_CODING_AGENT_SESSION_DIR=' && pass "pi env session dir" || fail "env" "missing: $ea"
+
+# --- parser slots ---
+SF2=$(mktemp)
+printf '%s\n' \
+  '{"type":"session","version":3,"id":"x","cwd":"/w"}' \
+  '{"type":"message","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}' \
+  '{"type":"message","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"PI_HELLO"}]}}' > "$SF2"
+out=$( ( source "$SCR/_lib.sh"; _load_driver pi; harness_parse_turn "$SF2" ) )
+echo "$out" | grep -q "PI_HELLO" && pass "pi parse_turn renders text" || fail "parse" "got: $out"
+lt=$( ( source "$SCR/_lib.sh"; _load_driver pi; harness_last_text "$SF2" ) )
+[ "$lt" = "PI_HELLO" ] && pass "pi last_text" || fail "last_text" "got: $lt"
+ct=$( ( source "$SCR/_lib.sh"; _load_driver pi; harness_count_text "$SF2" ) )
+[ "$ct" = "1" ] && pass "pi count_text" || fail "count" "got: $ct"
+rm -rf "$HOME_DIR" "$CWD" "$SF2"
+
+echo "pi-driver: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/tests/test-csd-pi.sh
+++ b/tests/test-csd-pi.sh
@@ -66,4 +66,24 @@ bash "$SCR/csd" poll pi "$SD3" "$WD3" "no-tmux-$$" >/dev/null 2>&1 || true
 [ -f "$WD3/$SID3.meta" ] && pass "csd poll self-registers" || fail "csd poll" "no meta"
 rm -rf "$SD3" "$WD3"
 
+# --- integration: fake-pi launch -> poller self-register -> read-turn -> multi-turn ---
+FAKE="$SCRIPT_DIR/fixtures/fake-pi"; chmod +x "$FAKE" 2>/dev/null || true
+IHOME=$(mktemp -d); mkdir -p "$IHOME/.claude" "$IHOME/.pi/agent"; touch "$IHOME/.claude/.claude-session-driver-consent"
+echo '{}' > "$IHOME/.pi/agent/auth.json"
+IWDIR=$(mktemp -d); ITN="test-pi-$$"; IWD=$(mktemp -d)
+run_csd(){ CSD_WORKER_DIR="$IWDIR" CSD_PI_BIN="$FAKE" HOME="$IHOME" bash "$SCR/csd" "$@"; }
+run_csd launch --harness pi "$ITN" "$IWD" >/dev/null 2>&1 || true
+sleep 2
+OUT=$(run_csd --worker "$ITN" read-turn 2>/dev/null || true)
+echo "$OUT" | grep -q "FAKE_PI_DONE" && pass "pi read-turn renders the turn" || fail "pi read-turn" "got: $OUT"
+ST=$(run_csd --worker "$ITN" status 2>/dev/null || true)
+[ "$ST" = "idle" ] && pass "pi status idle" || fail "pi status" "got: $ST"
+M=$(ls "$IWDIR"/*.meta 2>/dev/null | head -1)
+[ -n "$M" ] && [ "$(jq -r '.harness' "$M")" = "pi" ] && pass "pi meta self-registered" || fail "pi meta" "missing/wrong"
+OUT2=$(run_csd --worker "$ITN" converse "again" 4 2>/dev/null || true)
+echo "$OUT2" | grep -q FAKE_PI_DONE && fail "pi converse stale-turn" "echoed prior: $OUT2" || pass "pi converse waits for a new turn (no stale)"
+run_csd --worker "$ITN" stop >/dev/null 2>&1 || true
+tmux kill-session -t "$ITN" 2>/dev/null || true
+rm -rf "$IHOME" "$IWD" "$IWDIR"
+
 echo "pi-driver: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/tests/test-csd-pi.sh
+++ b/tests/test-csd-pi.sh
@@ -57,4 +57,13 @@ ct=$( ( source "$SCR/_lib.sh"; _load_driver pi; harness_count_text "$SF2" ) )
 [ "$ct" = "1" ] && pass "pi count_text" || fail "count" "got: $ct"
 rm -rf "$HOME_DIR" "$CWD" "$SF2"
 
+# --- csd poll subcommand self-registers (self-exits vs a missing tmux) ---
+SD3=$(mktemp -d); WD3=$(mktemp -d)
+SID3="019e0000-0000-7000-8000-0000000000bb"
+printf '{"type":"session","version":3,"id":"%s","cwd":"/w"}\n' "$SID3" > "$SD3/x_${SID3}.jsonl"
+printf '{"type":"message","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"Z"}]}}\n' >> "$SD3/x_${SID3}.jsonl"
+bash "$SCR/csd" poll pi "$SD3" "$WD3" "no-tmux-$$" >/dev/null 2>&1 || true
+[ -f "$WD3/$SID3.meta" ] && pass "csd poll self-registers" || fail "csd poll" "no meta"
+rm -rf "$SD3" "$WD3"
+
 echo "pi-driver: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/tests/test-csd-pi.sh
+++ b/tests/test-csd-pi.sh
@@ -33,6 +33,27 @@ ev_seq=$(jq -r '.event' "$EV" 2>/dev/null | tr '\n' ',')
 echo "$ev_seq" | grep -q 'session_start,user_prompt_submit,pre_tool_use,post_tool_use,stop' && pass "poller synthesizes the event sequence" || fail "events" "got $ev_seq"
 rm -rf "$SD" "$WDIR"
 
+# Regression: any non-toolUse terminal stopReason must emit `stop` (forward-compat).
+SDx=$(mktemp -d); WDx=$(mktemp -d); SIDx="019e0000-0000-7000-8000-0000000000cc"
+{
+  printf '{"type":"session","version":3,"id":"%s","cwd":"/w"}\n' "$SIDx"
+  printf '{"type":"message","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}\n'
+  printf '{"type":"message","message":{"role":"assistant","stopReason":"length","content":[{"type":"text","text":"PARTIAL"}]}}\n'
+} > "$SDx/a_${SIDx}.jsonl"
+( source "$SCR/_lib.sh"; _load_driver pi; harness_poll "$SDx" "$WDx" "no-tmux-$$" ) >/dev/null 2>&1 || true
+grep -q '"event":"stop"' "$WDx/$SIDx.events.jsonl" 2>/dev/null && pass "non-stop terminal stopReason emits stop" || fail "terminal stopReason" "no stop event"
+rm -rf "$SDx" "$WDx"
+
+# Regression: the poller tails the NEWEST session file, not an arbitrary one.
+SDn=$(mktemp -d); WDn=$(mktemp -d)
+OLDID="019e0000-0000-7000-8000-0000000000d1"; NEWID="019e0000-0000-7000-8000-0000000000d2"
+printf '{"type":"session","version":3,"id":"%s","cwd":"/w"}\n{"type":"message","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"OLD"}]}}\n' "$OLDID" > "$SDn/old_${OLDID}.jsonl"
+sleep 1
+printf '{"type":"session","version":3,"id":"%s","cwd":"/w"}\n{"type":"message","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"NEW"}]}}\n' "$NEWID" > "$SDn/new_${NEWID}.jsonl"
+( source "$SCR/_lib.sh"; _load_driver pi; harness_poll "$SDn" "$WDn" "no-tmux-$$" ) >/dev/null 2>&1 || true
+[ -f "$WDn/$NEWID.meta" ] && pass "poller registers the newest session" || fail "newest file" "registered wrong/none"
+rm -rf "$SDn" "$WDn"
+
 # --- prepare + launch + env slots ---
 HOME_DIR=$(mktemp -d); CWD=$(mktemp -d)
 ( source "$SCR/_lib.sh"; _load_driver pi; CSD_PLUGIN_DIR=/plug HOME=/nonexistent harness_prepare wkr "$CWD" "$HOME_DIR" )

--- a/tests/test-csd-provider-env.sh
+++ b/tests/test-csd-provider-env.sh
@@ -19,12 +19,12 @@ set -euo pipefail
 #                                     inherit, alongside its credentials.
 #
 # Strategy: a stub `claude` dumps the provider/auth env it actually received to
-# /tmp/claude-workers/<sid>.env-dump. We launch with controlled controller env
+# /tmp/csd-workers/<sid>.env-dump. We launch with controlled controller env
 # and a deliberately-polluted tmux global env, then inspect the dump.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -90,16 +90,16 @@ cat > "$FAKE_CLAUDE" <<'BASH'
 #!/bin/bash
 SID=""
 while [ $# -gt 0 ]; do case "$1" in --session-id) SID="$2"; shift 2 ;; *) shift ;; esac; done
-mkdir -p /tmp/claude-workers
+mkdir -p /tmp/csd-workers
 {
   for v in CLAUDE_CODE_SSE_PORT CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST \
            CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY \
            CLAUDE_CODE_USE_ANTHROPIC_AWS CLAUDE_CODE_USE_MANTLE; do
     if val=$(printenv "$v"); then printf '%s=[%s]\n' "$v" "$val"; else printf '%s=UNSET\n' "$v"; fi
   done
-} > "/tmp/claude-workers/${SID}.env-dump"
+} > "/tmp/csd-workers/${SID}.env-dump"
 echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"event\":\"session_start\",\"cwd\":\"$PWD\"}" \
-  > "/tmp/claude-workers/${SID}.events.jsonl"
+  > "/tmp/csd-workers/${SID}.events.jsonl"
 exec sleep 60
 BASH
 chmod +x "$FAKE_CLAUDE"

--- a/tests/test-csd-read-events.sh
+++ b/tests/test-csd-read-events.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0

--- a/tests/test-csd-read-turn.sh
+++ b/tests/test-csd-read-turn.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -12,7 +12,7 @@ fail() { echo "  FAIL: $1 - $2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
 
 # Use a synthetic HOME so we don't touch the real ~/.claude/projects.
 FAKE_HOME=$(mktemp -d)
-trap 'rm -rf "$FAKE_HOME"; rm -f /tmp/claude-workers/test-rt-*.meta /tmp/claude-workers/test-rt-*.events.jsonl' EXIT
+trap 'rm -rf "$FAKE_HOME"; rm -f /tmp/csd-workers/test-rt-*.meta /tmp/csd-workers/test-rt-*.events.jsonl' EXIT
 mkdir -p "$WDIR"
 
 SID="test-rt-001"

--- a/tests/test-csd-readers.sh
+++ b/tests/test-csd-readers.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -42,7 +42,7 @@ fi
 # --- events-file path ---
 echo "Test 3: events-file"
 OUTPUT=$(bash "$CSD" --worker "$TMUX_NAME" events-file)
-EXPECTED="/tmp/claude-workers/$SESSION_ID.events.jsonl"
+EXPECTED="/tmp/csd-workers/$SESSION_ID.events.jsonl"
 if [ "$OUTPUT" = "$EXPECTED" ]; then
   pass "events-file path"
 else

--- a/tests/test-csd-send.sh
+++ b/tests/test-csd-send.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0

--- a/tests/test-csd-status.sh
+++ b/tests/test-csd-status.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0

--- a/tests/test-csd-stop.sh
+++ b/tests/test-csd-stop.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0

--- a/tests/test-csd-wait-for-turn.sh
+++ b/tests/test-csd-wait-for-turn.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CSD="$SCRIPT_DIR/../skills/driving-claude-code-sessions/scripts/csd"
-WDIR=/tmp/claude-workers
+WDIR=/tmp/csd-workers
 
 PASS_COUNT=0
 FAIL_COUNT=0

--- a/tests/test-emit-event-codex.sh
+++ b/tests/test-emit-event-codex.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/emit-event-codex"
+PASS=0; FAIL=0
+pass(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail(){ echo "  FAIL: $1 - $2"; FAIL=$((FAIL+1)); }
+WD=$(mktemp -d)
+SID="019e0000-0000-7000-8000-000000000001"
+
+# SessionStart self-registers the meta from the payload.
+printf '%s' "{\"session_id\":\"$SID\",\"transcript_path\":\"/r/$SID.jsonl\",\"cwd\":\"/w\",\"hook_event_name\":\"SessionStart\"}" \
+  | "$HOOK" my-worker /w "$WD"
+[ -f "$WD/$SID.meta" ] && pass "meta self-registered" || fail "meta" "missing"
+[ "$(jq -r '.harness' "$WD/$SID.meta")" = "codex" ] && pass "harness=codex" || fail "harness" "wrong"
+[ "$(jq -r '.tmux_name' "$WD/$SID.meta")" = "my-worker" ] && pass "tmux_name baked" || fail "tmux_name" "wrong"
+[ "$(jq -r '.transcript_path' "$WD/$SID.meta")" = "/r/$SID.jsonl" ] && pass "transcript_path captured" || fail "tp" "wrong"
+[ "$(tail -1 "$WD/$SID.events.jsonl" | jq -r '.event')" = "session_start" ] && pass "session_start event" || fail "event" "wrong"
+
+# PreToolUse carries the tool name.
+printf '%s' "{\"session_id\":\"$SID\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\"}" | "$HOOK" my-worker /w "$WD"
+[ "$(tail -1 "$WD/$SID.events.jsonl" | jq -r '.tool')" = "Bash" ] && pass "pre_tool_use tool" || fail "tool" "wrong"
+
+# B2: escaped JSON in tool_input must survive (read -r). Without -r, the payload
+# corrupts, jq bails, and no event is appended (tail would show the prior event).
+printf '%s' '{"session_id":"'"$SID"'","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo \"hi\" && ls\nfoo"}}' | "$HOOK" my-worker /w "$WD"
+got=$(tail -1 "$WD/$SID.events.jsonl" | jq -r '.tool_input.command')
+[ "$got" = 'echo "hi" && ls
+foo' ] && pass "escaped tool_input preserved (read -r)" || fail "escaped" "got: $got"
+
+# PostToolUse maps explicitly (no GNU \L fallback).
+printf '%s' "{\"session_id\":\"$SID\",\"hook_event_name\":\"PostToolUse\"}" | "$HOOK" my-worker /w "$WD"
+[ "$(tail -1 "$WD/$SID.events.jsonl" | jq -r '.event')" = "post_tool_use" ] && pass "post_tool_use mapped" || fail "posttool" "wrong"
+
+# Stop maps to turn-end.
+printf '%s' "{\"session_id\":\"$SID\",\"hook_event_name\":\"Stop\"}" | "$HOOK" my-worker /w "$WD"
+[ "$(tail -1 "$WD/$SID.events.jsonl" | jq -r '.event')" = "stop" ] && pass "stop event" || fail "stop" "wrong"
+
+# Missing session_id → no-op, exit 0 (don't break the agent).
+printf '%s' '{"hook_event_name":"Stop"}' | "$HOOK" my-worker /w "$WD" && pass "no-sid no-ops cleanly" || fail "no-sid" "nonzero exit"
+
+rm -rf "$WD"
+echo "emit-event-codex: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/tests/test-emit-event.sh
+++ b/tests/test-emit-event.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 EMIT_EVENT="$SCRIPT_DIR/../hooks/emit-event"
-EVENT_DIR="/tmp/claude-workers"
+EVENT_DIR="/tmp/csd-workers"
 
 PASS_COUNT=0
 FAIL_COUNT=0


### PR DESCRIPTION
Drive Codex and Pi workers alongside Claude Code. Pass `--harness codex` or `--harness pi` at launch; the rest of the surface — `converse`, `read-turn`, `stop`, `handoff` — is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)