### PR TITLE
fix(send): treat a mid-turn worker's prompt as queued, not a #20 failure

### DIFF
--- a/dist/csd.cjs
+++ b/dist/csd.cjs
@@ -1398,6 +1398,10 @@ async function pasteText(ctx, tmuxName, prompt) {
   const safe = prompt.split(PASTE_END).join("").split(PASTE_START).join("");
   await ctx.tmux.sendText(tmuxName, PASTE_START + safe + PASTE_END);
 }
+function workerMidTurn(eventFile) {
+  const last = lastEvent(eventFile);
+  return last !== null && classifyStatus(last) === "working";
+}
 async function confirmSubmission(ctx, tmuxName, eventFile, beforeLine, opts) {
   const submitTimeout = opts.submitTimeout ?? envNumber("CSD_SUBMIT_TIMEOUT", 10);
   const retryInterval = opts.retryInterval ?? envNumber("CSD_SUBMIT_RETRY_INTERVAL", 2);
@@ -1407,6 +1411,12 @@ async function confirmSubmission(ctx, tmuxName, eventFile, beforeLine, opts) {
   let sinceEnter = Date.now();
   while (!promptSubmittedSince(eventFile, beforeLine)) {
     if (Date.now() >= deadline) {
+      if (workerMidTurn(eventFile)) {
+        return {
+          stderr: `Note: worker '${tmuxName}' is mid-turn, so the prompt was queued behind the running turn. A queued prompt emits no user_prompt_submit of its own, so there is nothing further to confirm; it runs when the current turn ends. Use 'csd converse' (or 'csd wait-for-turn') if you need to wait for the reply.`,
+          code: 0
+        };
+      }
       return {
         stderr: `Error: prompt pasted but worker did not confirm submission within ${submitTimeout}s (issue #20). The tmux session may be slow to accept the paste; raise CSD_SUBMIT_TIMEOUT to allow more time.`,
         code: 1
@@ -1989,7 +1999,9 @@ Per-worker subcommands (require --worker, supplied by the shim):
   converse [--with-turn] <prompt> [timeout=120]
                        Send prompt, wait for turn, return assistant text.
                        --with-turn returns the full markdown turn instead
-  send <prompt>        Send a prompt without waiting for the turn
+  send <prompt>        Send a prompt without waiting for the turn. If the worker
+                       is mid-turn the prompt is queued, not submitted: exits 0
+                       with a note on stderr. Do not re-send
   wait-for-turn [timeout=60] [--after-line N]
                        Block until the next stop OR session_end. By default the
                        baseline is the events file's current end, so it waits for

--- a/skills/driving-claude-code-sessions/SKILL.md
+++ b/skills/driving-claude-code-sessions/SKILL.md
@@ -113,6 +113,8 @@ If you need to drive the worker more directly:
 /tmp/csd-workers/bin/my-task read-turn --full                    # last turn with complete tool results
 ```
 
+`send` returns as soon as the worker confirms the prompt — or, if the worker is mid-turn, as soon as the prompt is queued (see [Sending to a worker that is already busy](#sending-to-a-worker-that-is-already-busy)). Use `converse` when you want the reply.
+
 ### 4. Watching what the worker does
 
 Every tool call emits a `pre_tool_use` event with the tool name and input. Tail the event stream to watch in real time:
@@ -230,6 +232,22 @@ Don't trust worker B's summary of what it did — check the produced file. A wor
 
 `wait-for-turn` matches `stop` OR `session_end`, so it returns when the worker dies. Call `status` afterward: if it's `gone`, the worker crashed.
 
+### Sending to a worker that is already busy
+
+A worker that is mid-turn cannot take a prompt as a new turn: Claude Code *queues* it (the pane shows `Press up to edit queued messages`) and runs it when the current turn ends. A queued prompt emits **no `user_prompt_submit` and no `stop` of its own** — the whole queued turn is invisible to the event stream, and a single `stop` closes both turns.
+
+So `send` has nothing left to confirm. It delivers the prompt, reports this on stderr and exits **0**:
+
+```
+Note: worker 'my-task' is mid-turn, so the prompt was queued behind the running turn. ...
+```
+
+Do **not** re-send after that note, and do **not** raise `CSD_SUBMIT_TIMEOUT` — the event `send` would be waiting for is never written for a queued prompt, so no timeout is long enough. Re-sending just double-delivers once the worker frees up. Call `status` first if you want to know before you send: `working` means the next `send` will queue.
+
+`converse` still works against a busy worker: it waits for the shared turn-end and reads the latest turn, which is the queued prompt's. The caveat is that csd cannot see the boundary between the two turns, so if the worker goes idle *between* them you get the earlier turn's reply — check `read-turn` if attribution matters.
+
+Only an *idle* worker that stays silent is a real failure — that is the paste-was-swallowed case, and `send` exits 1 there with the `CSD_SUBMIT_TIMEOUT` hint.
+
 ### After a `converse` timeout, check `status` before `wait-for-turn`
 
 A bare `wait-for-turn` baselines at the *current* end of the events file and waits for the **next** turn-end. If a `converse` timed out, the worker often finishes during the gap — the `stop` has already landed, so a follow-up `wait-for-turn` blocks the entire timeout waiting for a turn that will never start. After a timeout, call `status` first: `idle` means the turn already ended (`read-turn` to read it); `working` means it's still going.
@@ -279,7 +297,7 @@ The `csd` CLI honors a small set of env vars. All are optional.
 | `CSD_CODEX_MODEL` / `CSD_PI_MODEL` | Optional model override for codex / pi workers. Unset = the harness default (codex: `gpt-5.5`; pi: its configured default). |
 | `CSD_CONVERSE_DIAG_FILE` | When set, `csd converse` writes a post-mortem diagnostic on timeout — `ps` tree, `tmux capture-pane`, last 30 lines of the worker's session JSONL, last 20 lines of the csd events JSONL — to this path, then emits a `csd-diagnostic: <path>` pointer to stderr. The file is overwritten on each timeout. Unset = no diagnostic file. Useful when wrapping csd in a harness that can ship the file off-box before the worker is reaped. |
 | `CSD_WORKER_DIR` | Override the worker dir (default `/tmp/csd-workers`). The back-compat `/tmp/claude-workers` symlink is only created when the default is in use. |
-| `CSD_SUBMIT_TIMEOUT` / `CSD_SUBMIT_RETRY_INTERVAL` | `send`: seconds to wait for the worker to confirm a pasted prompt (default `10`) and seconds between retry-Enter resends (default `2`). Raise the timeout if a slow tmux session drops the paste. |
+| `CSD_SUBMIT_TIMEOUT` / `CSD_SUBMIT_RETRY_INTERVAL` | `send`: seconds to wait for the worker to confirm a pasted prompt (default `10`) and seconds between retry-Enter resends (default `2`). Raise the timeout if a slow tmux session drops the paste. Raising it does **not** help a worker that is mid-turn — that prompt is queued, and a queued prompt never emits the event `send` waits for. |
 | `CSD_REGISTER_TIMEOUT` | Seconds the FIRST `send`/`converse` to a derive worker (codex/pi) waits for it to self-register its session id (default `15`). |
 | `HOME` | Used to locate `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` (claude) and the one-time consent file (`~/.claude/.claude-session-driver-consent`). |
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,7 +101,9 @@ Per-worker subcommands (require --worker, supplied by the shim):
   converse [--with-turn] <prompt> [timeout=120]
                        Send prompt, wait for turn, return assistant text.
                        --with-turn returns the full markdown turn instead
-  send <prompt>        Send a prompt without waiting for the turn
+  send <prompt>        Send a prompt without waiting for the turn. If the worker
+                       is mid-turn the prompt is queued, not submitted: exits 0
+                       with a note on stderr. Do not re-send
   wait-for-turn [timeout=60] [--after-line N]
                        Block until the next stop OR session_end. By default the
                        baseline is the events file's current end, so it waits for

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -1,4 +1,4 @@
-import { readRawLines } from '../core/event-log.js';
+import { classifyStatus, lastEvent, readRawLines } from '../core/event-log.js';
 import { eventsPath } from '../core/paths.js';
 import { resolveSession } from '../core/worker-store.js';
 import { parseEvent } from '../events.js';
@@ -193,12 +193,32 @@ async function pasteText(
 }
 
 /**
+ * True when the worker's last event says it is still inside a turn. Pasting into
+ * a worker in that state gets the prompt QUEUED (Claude Code shows "Press up to
+ * edit queued messages"), and a queued prompt emits no `user_prompt_submit` of
+ * its own — verified against Claude Code 2.1.237: the queued turn runs and
+ * answers, but the only events written are the in-flight turn's, and one `stop`
+ * closes both. Mirrors `status`' classification so the two never disagree.
+ */
+function workerMidTurn(eventFile: string): boolean {
+  const last = lastEvent(eventFile);
+  return last !== null && classifyStatus(last) === 'working';
+}
+
+/**
  * Send Enter and re-send it every `retryInterval` seconds until the worker emits
  * `user_prompt_submit` after `beforeLine`, or `submitTimeout` elapses. Shared by
  * the assign and derive paths.
  *
  * The harness converts the bracketed paste into a pending-input widget
  * asynchronously; an Enter sent too early can be swallowed (issue #20).
+ *
+ * Running out of time is not automatically a failure. If the worker is still
+ * mid-turn the prompt was queued, and a queued prompt never emits its own
+ * `user_prompt_submit` — so the event this loop waits for will never be written,
+ * no matter how high `CSD_SUBMIT_TIMEOUT` is set. Report that as success with a
+ * note rather than the #20 paste-swallowed error, whose "raise the timeout"
+ * advice cannot help there.
  */
 async function confirmSubmission(
   ctx: CommandContext,
@@ -218,6 +238,12 @@ async function confirmSubmission(
   let sinceEnter = Date.now();
   while (!promptSubmittedSince(eventFile, beforeLine)) {
     if (Date.now() >= deadline) {
+      if (workerMidTurn(eventFile)) {
+        return {
+          stderr: `Note: worker '${tmuxName}' is mid-turn, so the prompt was queued behind the running turn. A queued prompt emits no user_prompt_submit of its own, so there is nothing further to confirm; it runs when the current turn ends. Use 'csd converse' (or 'csd wait-for-turn') if you need to wait for the reply.`,
+          code: 0,
+        };
+      }
       return {
         stderr: `Error: prompt pasted but worker did not confirm submission within ${submitTimeout}s (issue #20). The tmux session may be slow to accept the paste; raise CSD_SUBMIT_TIMEOUT to allow more time.`,
         code: 1,

--- a/tests/converse.test.ts
+++ b/tests/converse.test.ts
@@ -24,6 +24,7 @@ const SID = 'sid-converse';
 const TMUX_NAME = 'converse-worker';
 const CWD = '/home/user/project';
 
+const EARLIER_PROMPT = '{"type":"user","message":{"content":"earlier prompt"}}';
 const ASSISTANT_BEFORE =
   '{"type":"assistant","message":{"content":[{"type":"text","text":"earlier reply"}]}}';
 const USER_PROMPT = '{"type":"user","message":{"content":"do the thing"}}';
@@ -161,6 +162,75 @@ describe('cmdConverse', () => {
     expect(result.code).toBe(0);
     expect(result.stdout).toContain('**Prompt:** do the thing');
     expect(result.stdout).toContain('the fresh answer');
+  });
+
+  it('reaches the reply when send had to queue the prompt', async () => {
+    const ef = eventsPath(workerDir, SID);
+    // Worker mid-turn: send can only queue, and returns 0 with a note. The
+    // queued turn emits no events of its own — one `stop` closes both turns —
+    // so converse must still get there off that shared turn-end.
+    appendEvent(ef, {
+      event: 'user_prompt_submit',
+      ts: '2025-01-01T00:00:00Z',
+    });
+    appendEvent(ef, {
+      event: 'pre_tool_use',
+      ts: '2025-01-01T00:00:01Z',
+      tool: 'Bash',
+      tool_input: { command: 'ping -c 45 127.0.0.1' },
+    });
+    writeTranscript(home, [EARLIER_PROMPT, ASSISTANT_BEFORE].join('\n'));
+
+    let scheduled = false;
+    const timers: NodeJS.Timeout[] = [];
+    const tmux: Tmux = {
+      async hasSession() {
+        return true;
+      },
+      async killSession() {},
+      async capturePane() {
+        return '';
+      },
+      async capturePaneFull() {
+        return '';
+      },
+      async sendText() {},
+      async sendEnter() {
+        if (scheduled) return;
+        scheduled = true;
+        // No user_prompt_submit for the queued prompt: it just runs, and a
+        // single stop lands once the worker finally goes idle.
+        timers.push(
+          setTimeout(() => {
+            writeTranscript(
+              home,
+              [
+                EARLIER_PROMPT,
+                ASSISTANT_BEFORE,
+                USER_PROMPT,
+                ASSISTANT_AFTER,
+              ].join('\n'),
+            );
+            appendEvent(ef, { event: 'stop', ts: '2025-01-01T00:00:04Z' });
+          }, 120),
+        );
+      },
+      async sendKey() {},
+      async newSession() {},
+      async respawnPane() {},
+    };
+
+    const ctx = makeCtx(workerDir, home, tmux);
+    try {
+      const result = await cmdConverse(ctx, SID, 'do the thing', {
+        ...fastOpts,
+        sendOpts: { submitTimeout: 0.05, retryInterval: 2, pollMs: 5 },
+      });
+      expect(result.code).toBe(0);
+      expect(result.stdout).toBe('the fresh answer');
+    } finally {
+      for (const t of timers) clearTimeout(t);
+    }
   });
 
   it('errors when meta has no cwd', async () => {

--- a/tests/send.test.ts
+++ b/tests/send.test.ts
@@ -198,6 +198,54 @@ describe('cmdSend', () => {
     );
   });
 
+  it('errors when the worker is idle and never confirms', async () => {
+    const ef = eventsPath(workerDir, SID);
+    // Last event is a turn-end, so the worker was free to accept the prompt:
+    // silence here really is the issue #20 paste-swallowed case.
+    appendEvent(ef, { event: 'stop', ts: '2025-01-01T00:00:00Z' });
+    const calls: FakeTmuxCalls = { sendText: [], sendEnter: [] };
+    const ctx = makeCtx(workerDir, fakeTmux(true, calls));
+    const result = await cmdSend(ctx, SID, 'hi', {
+      submitTimeout: 0.1,
+      retryInterval: 2,
+      pollMs: 10,
+    });
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('did not confirm submission');
+  });
+
+  it('reports success with a note when the worker is mid-turn', async () => {
+    const ef = eventsPath(workerDir, SID);
+    // Pasting into a worker that is inside a turn queues the prompt, and a
+    // queued prompt emits no user_prompt_submit of its own — the event this
+    // loop waits for is never written. Waiting longer cannot help, so this must
+    // not be the #20 error.
+    appendEvent(ef, {
+      event: 'user_prompt_submit',
+      ts: '2025-01-01T00:00:00Z',
+    });
+    appendEvent(ef, {
+      event: 'pre_tool_use',
+      ts: '2025-01-01T00:00:01Z',
+      tool: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+    const calls: FakeTmuxCalls = { sendText: [], sendEnter: [] };
+    const ctx = makeCtx(workerDir, fakeTmux(true, calls));
+    const result = await cmdSend(ctx, SID, 'hi', {
+      submitTimeout: 0.1,
+      retryInterval: 2,
+      pollMs: 10,
+    });
+    expect(result.code).toBe(0);
+    expect(result.stderr).toContain('mid-turn');
+    expect(result.stderr).toContain('queued');
+    // The prompt still went in, so it is there to be submitted at turn end.
+    expect(calls.sendText).toEqual([
+      { name: TMUX_NAME, text: `${PASTE_START}hi${PASTE_END}` },
+    ]);
+  });
+
   it('strips paste markers embedded in the prompt', async () => {
     const ef = eventsPath(workerDir, SID);
     const calls: FakeTmuxCalls = { sendText: [], sendEnter: [] };


### PR DESCRIPTION
## Summary

`send` to a worker that is **mid-turn** always fails, with an error whose advice cannot work.

`confirmSubmission` waits for a `user_prompt_submit` event and, on timeout, reports:

```
Error: prompt pasted but worker did not confirm submission within 10s (issue #20).
The tmux session may be slow to accept the paste; raise CSD_SUBMIT_TIMEOUT to allow more time.
```

**Why that's wrong:** pasting into a busy worker does not start a new turn. Claude Code *queues* the prompt and runs it when the current turn ends. The pane at the moment `send` gives up:

```
✢ Whatchamacalliting… (21s · ↓ 143 tokens)
  ❯ V4-BUSY-TEST: reply with only DONE-V4.
────────────────────────────────────────────────
❯ Press up to edit queued messages
```

A queued prompt emits **no `user_prompt_submit` and no `stop` of its own**: the entire queued turn is invisible to the event stream, and a single `stop` closes both turns.

So the confirm loop is waiting for an event that is never written. `CSD_SUBMIT_TIMEOUT` cannot fix that at any value.

Consequences:

1. **Misleading failure.** The controller reads exit 1 as "prompt lost" and re-sends — which double-delivers once the worker frees up.
2. **`converse` can't talk to a busy worker at all**, since it propagates `send`'s non-zero result (`converse.ts`, `if (sendResult.code !== 0) return sendResult`).

## Reproduction

Against **Claude Code 2.1.237**, a clean `v4.0.0` checkout (`d97d1eb`) and its prebuilt `dist/`, on a real tmux worker.

> Note: `sleep` in the foreground is blocked in Claude Code workers, so a `sleep`-based prompt returns in seconds and the worker is never actually busy. Use a workload that genuinely occupies a turn — `ping -c 45` works.

```bash
csd launch v4verify /tmp/v4verify-cwd
SHIM=/tmp/csd-workers/bin/v4verify

# 1. occupy the worker for ~45s
$SHIM send "Run this exact command in the foreground and wait for it to finish: ping -c 45 127.0.0.1 | tail -3"
$SHIM status            # -> working   (wait for the pre_tool_use to land)

# 2. send while it is genuinely mid-turn
CSD_SUBMIT_TIMEOUT=12 $SHIM send "V4-BUSY-TEST: reply with only DONE-V4."
# -> Error: prompt pasted but worker did not confirm submission within 12s (issue #20). ...
# exit 1
```

The prompt was **not** lost. The pane, once the turn ends:

```
❯ V4-BUSY-TEST: reply with only DONE-V4.
⏺ DONE-V4
```

And the complete event file for that session — note there is no second `user_prompt_submit`, and one `stop` for both turns:

```
{"event":"session_start","ts":"2026-08-20T17:02:26Z","cwd":"/private/tmp/v4verify-cwd"}
{"event":"user_prompt_submit","ts":"2026-08-20T17:02:30Z"}
{"event":"pre_tool_use","ts":"2026-08-20T17:02:34Z","tool":"Bash","tool_input":{"command":"ping -c 45 127.0.0.1 | tail -3","timeout":120000,"description":"Ping localhost 45 times"}}
{"event":"stop","ts":"2026-08-20T17:03:21Z"}
```

**Control** — the identical send to an *idle* worker exits 0 in ~1s and the event appears immediately. (Also verified with dim "suggested" text sitting in the composer, which does not affect it.)

**After this change** — same busy-worker setup, driving the patched build directly (`node dist/csd.cjs`) rather than the shim, which still points at the stock bundle:

```
$ CSD_SUBMIT_TIMEOUT=12 node dist/csd.cjs --worker <sid> send "V4-FIX-TEST: reply with only DONE-FIX."
Note: worker 'v4verify' is mid-turn, so the prompt was queued behind the running turn.
A queued prompt emits no user_prompt_submit of its own, so there is nothing further
to confirm; it runs when the current turn ends. Use 'csd converse' (or 'csd
wait-for-turn') if you need to wait for the reply.
exit 0   (12s — the confirm window, then the classification)

$ node dist/csd.cjs --worker <sid> converse "V4-CONV2-TEST: reply with only DONE-CONV2." 120
DONE-CONV2
exit 0   (45s)
```

## Changes

- **`send`** — on timeout, classify the worker the same way `status` does (`classifyStatus(lastEvent(...))`, so the two can never disagree). Still `working` means the prompt was queued, not dropped: exit **0** with a note on stderr. An idle worker that stays silent is untouched — that is still the genuine #20 failure, with the same message and exit 1.
- **`converse`** — no code change needed. The `send` fix unblocks it, and it gets to the right reply off the shared turn-end (verified above). I tried re-baselining it on the queued prompt's own `user_prompt_submit` and **that was wrong** — no such event exists, so it just burned the full timeout.
- **Docs** — SKILL.md gets a "Sending to a worker that is already busy" edge case, a `send` vs `converse` pointer, and a caveat on the `CSD_SUBMIT_TIMEOUT` row; matching line in `csd help`.
- `dist/` rebuilt and committed in the same commit.

## Known limitation

Because the queued turn emits no events, csd cannot see the boundary between the two turns. `converse` reads the latest transcript turn after the shared `stop`, which is the queued prompt's — but if the worker went idle *between* the two turns you would get the earlier reply. Documented in SKILL.md rather than worked around, since detecting it would mean pane-scraping.

## Open question for you

**Retry-Enter cadence, deliberately left alone.** It is the only guard against the #20 paste-conversion race, and on the busy path nothing else will ever re-submit a paste whose Enter was swallowed. Extra Enters land on an empty composer once the prompt is queued. Happy to gate them on the busy path if you'd rather; it just seemed like the wrong trade to make silently.

## Testing

- `tests/send.test.ts`
  - mid-turn worker → code 0, note mentions `mid-turn`/`queued`, paste still sent (**fails before this change**)
  - idle worker that never confirms → still code 1 with the #20 message (passes before and after; guards the #20 path against the new branch)
- `tests/converse.test.ts`
  - busy worker, queued turn emits no events of its own, one `stop` closes both → `converse` still returns the queued prompt's reply (**fails before this change**)
- Gates green locally and in CI: `pnpm lint`, `pnpm typecheck`, `pnpm run dist:check`, `pnpm test` — **413 passed / 41 files** (410 before).
