### PR TITLE
fix: restore execute bit on dist/csd.cjs so grant-consent instruction works (#24)

### DIFF
--- a/dist/csd.cjs
+++ b/dist/csd.cjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 "use strict";
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/emit-event.cjs
+++ b/dist/emit-event.cjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 "use strict";
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,6 +7,14 @@ import { defineConfig } from 'tsup';
 // with NO runtime require of the other dist bundles. Only the CJS config has
 // `clean: true`; it owns wiping dist (a second clean would race-delete the
 // first config's output).
+//
+// `dist/csd.cjs` also has to run as a standalone script — the consent-gate
+// error prints its path directly (`<csdPath> grant-consent`), not `node
+// <csdPath> grant-consent` (src/commands/launch.ts). That needs BOTH a
+// shebang (banner, below) and the execute bit (onSuccess, below) or the
+// printed instruction fails: no exec bit -> `Permission denied`; exec bit but
+// no shebang -> the kernel hands the bundle to /bin/sh, which chokes on the
+// first line of JS.
 export default defineConfig([
   {
     entry: {
@@ -19,6 +27,14 @@ export default defineConfig([
     splitting: false,
     format: ['cjs'],
     outExtension: () => ({ js: '.cjs' }),
+    banner: { js: '#!/usr/bin/env node' },
+    // esbuild happens to chmod +x an output that starts with a shebang, so
+    // this alone gets us most of the way there — but that's an esbuild
+    // implementation detail, not a tsup contract, so don't rely on it
+    // silently. Set the bit explicitly as a backstop; `dist:check` (which
+    // rebuilds and diffs dist/) will fail the build if either mechanism ever
+    // regresses.
+    onSuccess: 'chmod +x dist/csd.cjs',
   },
   {
     entry: {


### PR DESCRIPTION
## Problem

The consent-gate error tells the user to run the CLI directly:

```
Run: <plugin-cache>/claude-session-driver/4.0.0/dist/csd.cjs grant-consent
```

But `dist/csd.cjs` is checked into the repo as mode `100644` (no execute
bit) — `git ls-files -s dist/` shows:

```
100644 8918930feaa69c4302432e7fc926c35a37c427f6 0    dist/csd.cjs
```

So following the printed instruction fails with `Permission denied`.

Fixing just the execute bit turned out not to be quite enough: `dist/csd.cjs`
also has no shebang line, so even with the execute bit set, the kernel hands
the bundle to `/bin/sh` (there's no `#!` to route it to `node`), and it fails
immediately on the first line of JS (`"use strict"` isn't valid shell). A
standalone-executable script needs both a shebang and the execute bit.

## Fix

- `tsup.config.ts` — add a `'#!/usr/bin/env node'` banner to the CJS build
  config (covers `csd.cjs` and `emit-event.cjs`, which share that config),
  plus an `onSuccess` hook that explicitly `chmod +x`'s `dist/csd.cjs` after
  every build. (esbuild happens to set the execute bit itself on any output
  that starts with a shebang, but that's an esbuild implementation detail,
  not a documented tsup contract, so the explicit chmod is a backstop rather
  than something we rely on silently.)
- `dist/csd.cjs`, `dist/emit-event.cjs` — rebuilt with the above. Committed
  mode changes from `100644` to `100755` on both files.

## How to verify

```
pnpm install
pnpm build
git diff --exit-code dist/   # or: pnpm run dist:check
git ls-files -s dist/csd.cjs # -> 100755
echo yes | ./dist/csd.cjs grant-consent   # runs instead of "Permission denied"
pnpm test
pnpm lint
pnpm typecheck
```

All green locally (398 passed / 12 skipped tests, clean biome + tsc).

Fixes #24
